### PR TITLE
Ensure Datadog secrets are passed to "Build and Deploy" workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,10 @@ on:
     secrets:
       AWS_ROLE_TO_ASSUME:
         required: true
+      DATADOG_API_KEY:
+        required: true
+      DATADOG_APP_KEY:
+        required: true
 
 concurrency:
   group: ${{ github.workflow_ref }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,4 +19,6 @@ jobs:
       tf_backend_config_file: prod.s3.tfbackend
       tf_var_file: prod.tfvars
     secrets:
-      AWS_ROLE_TO_ASSUME: ${{ secrets.PRODUCTION_ROLE_ARN }}
+      AWS_ROLE_TO_ASSUME: "${{ secrets.PRODUCTION_ROLE_ARN }}"
+      DATADOG_API_KEY: "${{ secrets.DATADOG_API_KEY }}"
+      DATADOG_APP_KEY: "${{ secrets.DATADOG_APP_KEY }}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,3 +22,5 @@ jobs:
       tf_var_file: staging.tfvars
     secrets:
       AWS_ROLE_TO_ASSUME: "${{ secrets.STAGING_ROLE_ARN }}"
+      DATADOG_API_KEY: "${{ secrets.DATADOG_API_KEY }}"
+      DATADOG_APP_KEY: "${{ secrets.DATADOG_APP_KEY }}"


### PR DESCRIPTION
## Description

Just like it says in the title :) 

In #25, the "Build and Deploy" workflow that is called by both "Deploy to Staging" and "Deploy to Production" workflows was edited to include secret values used to authenticate the Datadog terraform provider. However, the caller ("Deploy to X") workflows also need to be updated to pass the secrets as inputs to "Build and Deploy", since GitHub workflows that are triggered on `workflow_call` events [don't inherently have access to the caller's secrets](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow)*.

*Calling the reused workflow with `secrets: inherit` isn't a viable option here because we area already using the `secrets` parameter as an object to supply a custom-named secret. Plus, I prefer to keep secret-passing explicit.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [X] Added PR reviewers
