### PR TITLE
Fix: `error creating metric metadata` in Terraform

### DIFF
--- a/terraform/datadog_metrics.tf
+++ b/terraform/datadog_metrics.tf
@@ -1,12 +1,46 @@
-resource "datadog_metric_metadata" "custom" {
-  for_each = {
+locals {
+  datadog_metric_metadata_input = {
     for k, v in var.datadog_metrics_metadata :
     startswith(k, "grants_ingest.") ? k : "grants_ingest.${k}" => v
   }
+  datadog_metric_metadata_exists = {
+    for k in compact([
+      for k in keys(data.http.datadog_metric_metadata) :
+      (data.http.datadog_metric_metadata[k].status_code == 200 ? k : "")
+    ]) : k => local.datadog_metric_metadata_input[k]
+  }
+}
+
+/*
+This data source allows us to check which subset of metrics in local.datadog_metric_metadata_input
+are currently registered in Datadog (produce a 200 response).
+*/
+data "http" "datadog_metric_metadata" {
+  for_each = local.datadog_metric_metadata_input
+
+  url    = "https://api.datadoghq.com/api/v1/metrics/${each.key}"
+  method = "GET"
+
+  request_headers = {
+    Accept               = "application/json"
+    "DD-API-KEY"         = var.datadog_api_key
+    "DD-APPLICATION-KEY" = var.datadog_app_key
+  }
+}
+
+/*
+The datadog_metric_metadata resource only works when the underlying metric already exists.
+Therefore, these resources are dynamically provisioned according to the intersection of metrics
+that are: 1) defined in locals.datadog_metric_metadata_input, and 2) exist in Datadog.
+*/
+resource "datadog_metric_metadata" "custom" {
+  for_each = local.datadog_metric_metadata_exists
 
   metric      = each.key
   short_name  = each.value.short_name
   description = each.value.description
   unit        = each.value.unit
   per_unit    = each.value.per_unit
+
+  depends_on = [data.http.datadog_metric_metadata]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "DataDog/datadog"
       version = "~> 3.23.0"
     }
+    http = {
+      source = "hashicorp/http"
+      version = "3.2.1"
+    }
   }
   backend "s3" {}
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ terraform {
       version = "~> 3.23.0"
     }
     http = {
-      source = "hashicorp/http"
+      source  = "hashicorp/http"
       version = "3.2.1"
     }
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -88,12 +88,14 @@ variable "datadog_api_key" {
   description = "API key to use when provisioning Datadog resources."
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "datadog_app_key" {
   description = "Application key to use when provisioning Datadog resources."
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "datadog_draft" {


### PR DESCRIPTION
## Description

This PR contains a fix for the issue causing a [failing Terraform deployment](https://github.com/usdigitalresponse/grants-ingest/actions/runs/4613307469/jobs/8155147852) currently on `main`. 

### Problem

The `datadog_metric_metadata` Terraform resource fails to provision metadata when the named metric is not one that Datadog knows about. In our case, this is because one particular metric (`grants_ingest.SplitGrantsGovXMLDB.opportunity.failed`) has never been emitted (although it's also possible that Datadog metrics expire after enough time has past since it was last seen). However, we want to be able to define metadata for our metrics in Terraform without needing to worry about if/when the metric has fired (such as when rolling out code that implements a new metric).

### The Solution

We use Terraform's `http` data source to hit the Datadog API endpoint that allows us to check whether each metric already exists (in which case the HTTP request will result in a 200 response), and then dynamically filter the `datadog_metric_metadata` resource to only provision for those metrics.


## Testing

Terraform should deploy successfully to staging.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [X] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers
