### PR TITLE
Bump datadog-lambda-extension version from 38 to 41

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -145,7 +145,7 @@ variable "datadog_lambda_custom_tags" {
 variable "datadog_lambda_extension_version" {
   description = "Version to use for the Datadog Lambda Extension layer (when var.datadog_enabled is true)."
   type        = string
-  default     = "38"
+  default     = "41"
 }
 
 variable "datadog_metrics_metadata" {


### PR DESCRIPTION
### Chore

## Description

Bumps the default version of the [datadog-lambda-extension](https://github.com/DataDog/datadog-lambda-extension) layer from 38 to 41.

### Changelogs
- [v39](https://github.com/DataDog/datadog-lambda-extension/releases/tag/v39)
- [v40](https://github.com/DataDog/datadog-lambda-extension/releases/tag/v40)
- [v41](https://github.com/DataDog/datadog-lambda-extension/releases/tag/v41)
- Full diff: [v38...v41](https://github.com/DataDog/datadog-lambda-extension/compare/v38...v41)

## Testing

Verify that the terraform plan output includes a change for the `layers` attribute (showing a layer ARN ending in `:41`) for all `aws_lambda_function` resources.

### Automated and Unit Tests
- ~[ ] Added Unit tests~

### Manual tests for Reviewer
- [X] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers
