### PR TITLE
fix: adding IAM policy that allows SES to write to source data S3 bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -219,6 +219,34 @@ resource "aws_ses_receipt_rule" "ffis_ingest" {
   }
 }
 
+resource "aws_iam_policy" "ses_source_data_s3_access" {
+  name        = "ses_source_data_s3_access"
+  path        = "/"
+  description = "Allows SES to putObject into Grants source data bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Principal = {
+          Service = "ses.amazonaws.com"
+        }
+        Action = [
+          "s3:PutObject",
+        ]
+        Effect   = "Allow"
+        Resource = "${module.grants_source_data_bucket.bucket_id}/ses/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_ses_receipt_rule.ffis_ingest.arn
+            "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+    ]
+  })
+}
+
 // Lambda defaults
 locals {
   datadog_custom_tags = merge(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -238,7 +238,7 @@ resource "aws_iam_policy" "ses_source_data_s3_access" {
         Resource = "${module.grants_source_data_bucket.bucket_id}/ses/*"
         Condition = {
           StringEquals = {
-            "AWS:SourceArn" = aws_ses_receipt_rule.ffis_ingest.arn
+            "AWS:SourceArn"     = aws_ses_receipt_rule.ffis_ingest.arn
             "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
           }
         }


### PR DESCRIPTION
### Ticket #9 

## Description
Follow-up PR to #47, it looks like we need an IAM policy in place to allow SES to write to our source data S3 bucket.  This PR should fix that.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
