### PR TITLE
fix: SES receipt rule depends on IAM policy

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -205,6 +205,9 @@ data "aws_iam_policy_document" "read_datadog_api_key_secret" {
 }
 
 resource "aws_ses_receipt_rule" "ffis_ingest" {
+  depends_on = [
+    aws_iam_policy.ses_source_data_s3_access
+  ]
   name          = "ffis_ingest-${var.environment}"
   rule_set_name = "ffis_ingest-rule-set"
   recipients    = [var.ffis_ingest_email_address]


### PR DESCRIPTION
### Ticket #9 

## Description
Terraform is trying to create the SES receipt rule before the IAM policy which is still causing the apply to fail.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
