### PR TITLE
fix: IAM policy needs bucket ARN not bucket name

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -233,7 +233,7 @@ data "aws_iam_policy_document" "ses_source_data_s3_access" {
       "s3:PutObject",
     ]
 
-    resources = ["${module.grants_source_data_bucket.bucket_id}/ses/*"]
+    resources = ["${module.grants_source_data_bucket.bucket_arn}/ses/*"]
 
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
### Ticket #9 

## Description
Correcting a typo with this PR.  I accidentally defined the resource by name in this policy instead of the ARN.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
