### PR TITLE
fix: typo in the S3 bucket policy receipt rule condition

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -240,7 +240,7 @@ data "aws_iam_policy_document" "ses_source_data_s3_access" {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
       values = [
-        "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:receipt-rule-set/ffis_ingest-rule-set:receipt-rule/ffis_ingest-${var.environment}"
+        "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:receipt-rule-set/ffis_ingest-rule-set:receipt-rule/${var.namespace}-ffis_ingest"
       ]
     }
     condition {


### PR DESCRIPTION
### Ticket #9 

## Description
One of the conditions for this S3 bucket policy is broken. This PR fixes it.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
