### PR TITLE
fix: Correcting the SES email address for staging/local envs

### DIFF
--- a/terraform/local.tfvars
+++ b/terraform/local.tfvars
@@ -8,6 +8,8 @@ lambda_default_log_retention_in_days  = 7
 lambda_default_log_level              = "DEBUG"
 eventbridge_scheduler_enabled         = false
 ssm_deployment_parameters_path_prefix = "/grants-ingest/local"
+ffis_ingest_email_address             = "ffis-ingest@localhost.grants.usdr.dev"
+
 additional_lambda_environment_variables = {
   S3_USE_PATH_STYLE = "true"
 }

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -5,7 +5,7 @@ datadog_enabled                       = true
 lambda_default_log_retention_in_days  = 30
 lambda_default_log_level              = "INFO"
 datadog_draft                         = true
-ffis_ingest_email_address             = "ffis-ingest@staging.grants.usdigitalresponse.org"
+ffis_ingest_email_address             = "ffis-ingest@staging.grants.usdr.dev"
 
 // Only defined in staging
 datadog_metrics_metadata = {


### PR DESCRIPTION
### Ticket #61 

## Description
We're using the wrong domain for the staging SES email address for FFIS data. This PR fixes that.  I'm also setting a dummy value for local environments because this input parameter doesn't do any real validation outside of checking if the string looks like an email address or not.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
