### PR TITLE
fix: Designating FFIS receipt rule set as active in SES

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -235,6 +235,10 @@ resource "aws_ses_receipt_rule_set" "ffis_ingest" {
   rule_set_name = "${var.namespace}-ffis_ingest"
 }
 
+resource "aws_ses_active_receipt_rule_set" "active" {
+  rule_set_name = aws_ses_receipt_rule_set.ffis_ingest.rule_set_name
+}
+
 resource "aws_ses_receipt_rule" "ffis_ingest" {
   depends_on = [
     module.email_delivery_bucket


### PR DESCRIPTION
### Ticket #61 

## Description
We need to define an active receipt rule set in SES for AWS to consider this a valid mailbox

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
