### PR TITLE
Add Datadog service definition metadata

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.1/schema.json
+schema-version: v2.1
+application: Grants Ingest Service
+description: Ingests and indexes data from various sources related to grants.
+dd-service: grants-ingest
+team: usdr-grants
+contacts:
+  - type: slack
+    contact: https://usdigitalresponse.slack.com/archives/C0324KDQSCR
+links:
+  - name: Source
+    type: repo
+    provider: github
+    url: https://github.com/usdigitalresponse/grants-ingest
+  - name: Service Monitoring Dashboard
+    type: dashboard
+    url: https://app.datadoghq.com/dashboard/r2k-2tv-mui
+  - name: Project Development Board
+    type: other
+    url: https://github.com/orgs/usdigitalresponse/projects/5/views/9


### PR DESCRIPTION
## Description

This PR adds a `service.datadog.yaml` file that provides [service definition metadata](https://docs.datadoghq.com/tracing/service_catalog/service_metadata_structure) to Datadog. There's no impact to service behavior or infrastructure – this solely exists to facilitate service discovery in Datadog's [Service Catalog](https://docs.datadoghq.com/tracing/service_catalog/) offering.

## Testing

Not really – follow up after merge to ensure the service/repo is represented in the Datadog Service Catalog.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [X] Added PR reviewers
