### PR TITLE
Ffis spreadsheet download

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -110,6 +110,7 @@ tasks:
       - build-DownloadGrantsGovDB
       - build-SplitGrantsGovXMLDB
       - build-EnqueueFFISDownload
+      - build-DownloadFFISSpreadsheet
 
   build-DownloadGrantsGovDB:
     desc: Compiles DownloadGrantsGovDB
@@ -131,3 +132,10 @@ tasks:
       - task: build-lambda
         vars:
           LAMBDA_CMD: EnqueueFFISDownload
+
+  build-DownloadFFISSpreadsheet:
+    desc: Compiles DownloadFFISSpreadsheet
+    cmds:
+      - task: build-lambda
+        vars:
+          LAMBDA_CMD: DownloadFFISSpreadsheet

--- a/cmd/DownloadFFISSpreadsheet/handler.go
+++ b/cmd/DownloadFFISSpreadsheet/handler.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/DownloadFFISSpreadsheet/handler.go
+++ b/cmd/DownloadFFISSpreadsheet/handler.go
@@ -2,27 +2,82 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
+	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/usdigitalresponse/grants-ingest/internal/log"
+	ffis "github.com/usdigitalresponse/grants-ingest/pkg/grantsSchemas/ffis"
 )
 
 type SQSAPI interface {
-	SendMessage(ctx context.Context,
-		params *sqs.SendMessageInput,
-		optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
+	ReceiveMessage(ctx context.Context,
+		params *sqs.ReceiveMessageInput,
+		optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
 }
 
 type S3API interface {
-	GetObject(ctx context.Context,
-		params *s3.GetObjectInput,
-		optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	PutObject(ctx context.Context,
+		params *s3.PutObjectInput,
+		optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+
+	CreateMultipartUpload(ctx context.Context,
+		params *s3.CreateMultipartUploadInput,
+		optFns ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error)
+	AbortMultipartUpload(ctx context.Context,
+		params *s3.AbortMultipartUploadInput,
+		optFns ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
+
+	CompleteMultipartUpload(ctx context.Context,
+		params *s3.CompleteMultipartUploadInput,
+		optFns ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error)
+
+	UploadPart(ctx context.Context,
+		params *s3.UploadPartInput,
+		optFns ...func(*s3.Options)) (*s3.UploadPartOutput, error)
 }
 
 func handleSQSEvent(ctx context.Context, sqsEvent events.SQSEvent, s3client S3API, sqsclient SQSAPI) error {
 	msg := sqsEvent.Records[0].Body
-	fmt.Println(msg)
-	return fmt.Errorf("not implemented")
+	log.Info(logger, "Received message", "message", msg)
+	var ffisMessage ffis.FFISMessageDownload
+	err := json.Unmarshal([]byte(msg), &ffisMessage)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling SQS message: %w", err)
+	}
+
+	fileStr, err := parseSQSMessage(ffisMessage)
+	if err != nil {
+		return fmt.Errorf("error parsing SQS message: %w", err)
+	}
+	defer fileStr.Close()
+	err = writeToS3(ctx, s3client, fileStr, ffisMessage.SourceFileKey)
+	return err
+}
+
+func parseSQSMessage(msg ffis.FFISMessageDownload) (stream io.ReadCloser, err error) {
+	httpClient := http.Client{}
+	resp, err := httpClient.Get(msg.DownloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("error downloading file: %w", err)
+	}
+	log.Debug(logger, "Downloaded file", "url", msg.DownloadURL)
+	return resp.Body, nil
+}
+
+func writeToS3(ctx context.Context, s3client S3API, fileStr io.ReadCloser, sourceKey string) error {
+	log.Info(logger, "Writing to S3", "sourceKey", sourceKey, "destinationBucket", env.DestinationBucket)
+	_, err := s3manager.NewUploader(s3client).Upload(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(env.DestinationBucket),
+		Key:    aws.String("ffis/test.xlsx"), // TODO
+		Body:   fileStr,
+	})
+	return err
 }

--- a/cmd/DownloadFFISSpreadsheet/handler.go
+++ b/cmd/DownloadFFISSpreadsheet/handler.go
@@ -1,1 +1,28 @@
 package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+type SQSAPI interface {
+	SendMessage(ctx context.Context,
+		params *sqs.SendMessageInput,
+		optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
+}
+
+type S3API interface {
+	GetObject(ctx context.Context,
+		params *s3.GetObjectInput,
+		optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+func handleSQSEvent(ctx context.Context, sqsEvent events.SQSEvent, s3client S3API, sqsclient SQSAPI) error {
+	msg := sqsEvent.Records[0].Body
+	fmt.Println(msg)
+	return fmt.Errorf("not implemented")
+}

--- a/cmd/DownloadFFISSpreadsheet/handler.go
+++ b/cmd/DownloadFFISSpreadsheet/handler.go
@@ -63,7 +63,7 @@ func downloadFile(msg ffis.FFISMessageDownload, httpClient HTTPClientAPI) (strea
 
 func writeToS3(ctx context.Context, s3Uploader S3UploaderAPI, fileStr io.ReadCloser, sourceKey string) error {
 	destinationKey := strings.Replace(sourceKey, "ffis/raw.eml", "ffis/download.xlsx", 1)
-	log.Info(logger, "Writing to S3", "sourceKey", sourceKey, "destinationBucket", env.DestinationBucket)
+	log.Info(logger, "Writing to S3", "sourceKey", sourceKey, "destinationBucket", env.DestinationBucket, "destinationKey", destinationKey)
 	_, err := s3Uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(env.DestinationBucket),
 		Key:    &destinationKey,

--- a/cmd/DownloadFFISSpreadsheet/handler_test.go
+++ b/cmd/DownloadFFISSpreadsheet/handler_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/DownloadFFISSpreadsheet/handler_test.go
+++ b/cmd/DownloadFFISSpreadsheet/handler_test.go
@@ -1,1 +1,121 @@
 package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/go-kit/log"
+	"github.com/usdigitalresponse/grants-ingest/pkg/grantsSchemas/ffis"
+)
+
+type MockS3 struct {
+	content       []byte
+	key           string
+	responseError error
+}
+
+func (mockS3 *MockS3) Upload(ctx context.Context,
+	params *s3.PutObjectInput,
+	optFns ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(params.Body)
+	mockS3.content = buf.Bytes()
+	params.Body.Read(mockS3.content)
+	mockS3.key = *params.Key
+	return &s3manager.UploadOutput{}, mockS3.responseError
+}
+
+type MockHTTP struct {
+	testContent   []byte
+	responseError error
+	statusCode    int
+}
+
+func (mockHTTP *MockHTTP) Get(url string) (resp *http.Response, err error) {
+	bodyReaderClose := io.NopCloser(bytes.NewReader(mockHTTP.testContent))
+	mockStatusCode := http.StatusOK
+	if mockHTTP.statusCode != 0 {
+		mockStatusCode = mockHTTP.statusCode
+	}
+	return &http.Response{Body: bodyReaderClose, StatusCode: mockStatusCode}, mockHTTP.responseError
+}
+
+func TestHandleS3Event(t *testing.T) {
+	logger = log.NewNopLogger()
+	var tests = []struct {
+		name               string
+		message            ffis.FFISMessageDownload
+		httpError, s3Error error
+		httpStatusCode     int
+	}{
+		{name: "basic happy path",
+			message: ffis.FFISMessageDownload{DownloadURL: "https://www.example.com", SourceFileKey: "/sources/2023/05/01/ffis/raw.eml"}},
+		{name: "fails to download file",
+			message:   ffis.FFISMessageDownload{DownloadURL: "https://www.example.com", SourceFileKey: "/sources/2023/05/01/ffis/raw.eml"},
+			httpError: fmt.Errorf("Error downloading files")},
+		{name: "s3 upload fails",
+			message: ffis.FFISMessageDownload{DownloadURL: "https://www.example.com", SourceFileKey: "/sources/2023/05/01/ffis/raw.eml"},
+			s3Error: fmt.Errorf("Error uploading files")},
+		{name: "HTTP error",
+			message:        ffis.FFISMessageDownload{DownloadURL: "https://www.example.com", SourceFileKey: "/sources/2023/05/01/ffis/raw.eml"},
+			httpStatusCode: 500},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			msgJson, _ := json.Marshal(test.message)
+			sqsEvent := events.SQSEvent{
+				Records: []events.SQSMessage{
+					{
+						Body: string(msgJson),
+					},
+				},
+			}
+			mockUploader := &MockS3{responseError: test.s3Error}
+			mockHTTP := &MockHTTP{testContent: []byte("test content"), responseError: test.httpError, statusCode: test.httpStatusCode}
+			err := handleSQSEvent(context.Background(), sqsEvent, mockUploader, mockHTTP)
+			// check error content
+			if test.httpError == nil && test.s3Error == nil && test.httpStatusCode <= 200 {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				uploadedContent := string(mockUploader.content)
+				if uploadedContent != string(mockHTTP.testContent) {
+					t.Errorf("Expected %v, got %v", mockHTTP.testContent, uploadedContent)
+				}
+				expectedKey := strings.Replace(test.message.SourceFileKey, "raw.eml", "download.xlsx", 1)
+				if mockUploader.key != expectedKey {
+					t.Errorf("Expected %v, got %v", expectedKey, mockUploader.key)
+				}
+			}
+			if test.httpError != nil {
+				if !errorContains(err, test.httpError) {
+					t.Errorf("Expected error %v, got %v", test.httpError, err)
+				}
+			}
+			if test.s3Error != nil {
+				if !errorContains(err, test.s3Error) {
+					t.Errorf("Expected error %v, got %v", test.s3Error, err)
+				}
+			}
+			if test.httpStatusCode > 200 {
+				if !errorContains(err, ErrDownloadFailed) {
+					t.Errorf("Expected error %v, got %v", ErrDownloadFailed, err)
+				}
+			}
+		})
+	}
+}
+
+func errorContains(actual error, expected error) bool {
+	return strings.Contains(actual.Error(), expected.Error())
+}

--- a/cmd/DownloadFFISSpreadsheet/main.go
+++ b/cmd/DownloadFFISSpreadsheet/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/cmd/DownloadFFISSpreadsheet/main.go
+++ b/cmd/DownloadFFISSpreadsheet/main.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"fmt"
 	goLog "log"
+	"net/http"
 
 	ddlambda "github.com/DataDog/datadog-lambda-go"
 	goenv "github.com/Netflix/go-env"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/usdigitalresponse/grants-ingest/internal/awsHelpers"
 	"github.com/usdigitalresponse/grants-ingest/internal/log"
@@ -53,14 +55,7 @@ func main() {
 		s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 			o.UsePathStyle = env.UsePathStyleS3Opt
 		})
-
-		sqsClient, err := awsHelpers.GetSQSClient(ctx)
-		if err != nil {
-			return fmt.Errorf("could not create AWS clients: %w", err)
-		}
-		if err != nil {
-			return fmt.Errorf("could not create AWS clients: %w", err)
-		}
-		return handleSQSEvent(ctx, sqsEvent, s3Client, sqsClient)
+		httpClient := http.Client{}
+		return handleSQSEvent(ctx, sqsEvent, s3manager.NewUploader(s3Client), &httpClient)
 	}, nil))
 }

--- a/cmd/DownloadFFISSpreadsheet/main.go
+++ b/cmd/DownloadFFISSpreadsheet/main.go
@@ -8,15 +8,12 @@ import (
 	"context"
 	"fmt"
 	goLog "log"
-	"os"
 
 	ddlambda "github.com/DataDog/datadog-lambda-go"
 	goenv "github.com/Netflix/go-env"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/usdigitalresponse/grants-ingest/internal/awsHelpers"
 	"github.com/usdigitalresponse/grants-ingest/internal/log"
 	awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go-v2/aws"
@@ -53,34 +50,17 @@ func main() {
 		}
 		awstrace.AppendMiddleware(&cfg)
 		log.Debug(logger, "Starting Lambda")
-		s3client, sqsclient, err := buildClients(cfg)
+		s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.UsePathStyle = env.UsePathStyleS3Opt
+		})
+
+		sqsClient, err := awsHelpers.GetSQSClient(ctx)
 		if err != nil {
 			return fmt.Errorf("could not create AWS clients: %w", err)
 		}
-		return handleSQSEvent(ctx, sqsEvent, s3client, sqsclient)
-	}, nil))
-}
-
-func buildClients(cfg aws.Config) (S3API, SQSAPI, error) {
-	s3svc := s3.NewFromConfig(cfg, func(o *s3.Options) {
-		o.UsePathStyle = env.UsePathStyleS3Opt
-	})
-
-	log.Debug(logger, "Created S3 client", "client", s3svc)
-
-	var sqsResolver sqs.EndpointResolverFunc = func(region string, options sqs.EndpointResolverOptions) (aws.Endpoint, error) {
-		return cfg.EndpointResolverWithOptions.ResolveEndpoint("sqs", cfg.Region)
-	}
-	sqssvc := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
-		// the logic in internal/awsHelpers/config doesn't affect the endpoint for SQS, and this is
-		// needed so that localstack will work
-		if _, isSet := os.LookupEnv("LOCALSTACK_HOSTNAME"); isSet {
-			o.EndpointResolver = sqsResolver
+		if err != nil {
+			return fmt.Errorf("could not create AWS clients: %w", err)
 		}
-	})
-
-	log.Debug(logger, "Created SQS client", "client", sqssvc)
-
-	return s3svc, sqssvc, nil
-
+		return handleSQSEvent(ctx, sqsEvent, s3Client, sqsClient)
+	}, nil))
 }

--- a/cmd/DownloadFFISSpreadsheet/main.go
+++ b/cmd/DownloadFFISSpreadsheet/main.go
@@ -1,5 +1,86 @@
+// Package main compiles to an AWS Lambda handler binary that, when invoked,
+// parses the email found in the event payload for a link to the FFIS data, and
+// enqueue a message to the SQS queue named by the FFIS_SQS_QUEUE_NAME environment
+
 package main
 
+import (
+	"context"
+	"fmt"
+	goLog "log"
+	"os"
+
+	ddlambda "github.com/DataDog/datadog-lambda-go"
+	goenv "github.com/Netflix/go-env"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/usdigitalresponse/grants-ingest/internal/awsHelpers"
+	"github.com/usdigitalresponse/grants-ingest/internal/log"
+	awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go-v2/aws"
+)
+
+type Environment struct {
+	LogLevel          string `env:"LOG_LEVEL,default=INFO"`
+	UsePathStyleS3Opt bool   `env:"S3_USE_PATH_STYLE,default=false"`
+	DestinationBucket string `env:"TARGET_BUCKET_NAME,required=true"`
+	Extras            goenv.EnvSet
+}
+
+var (
+	env    Environment
+	logger log.Logger
+	// sendMetric       = ddHelpers.NewMetricSender("DownloadFFISSpreadsheet", "source:grants.gov")
+)
+
 func main() {
+	es, err := goenv.UnmarshalFromEnviron(&env)
+	if err != nil {
+		goLog.Fatalf("error configuring environment variables: %v", err)
+	}
+	env.Extras = es
+	log.ConfigureLogger(&logger, env.LogLevel)
+
+	log.Info(logger, "Starting DownloadFFISSpreadsheet", "destinationBucket", env.DestinationBucket)
+
+	log.Debug(logger, "Starting Lambda")
+	lambda.Start(ddlambda.WrapFunction(func(ctx context.Context, sqsEvent events.SQSEvent) error {
+		cfg, err := awsHelpers.GetConfig(ctx)
+		if err != nil {
+			return fmt.Errorf("could not create AWS SDK config: %w", err)
+		}
+		awstrace.AppendMiddleware(&cfg)
+		log.Debug(logger, "Starting Lambda")
+		s3client, sqsclient, err := buildClients(cfg)
+		if err != nil {
+			return fmt.Errorf("could not create AWS clients: %w", err)
+		}
+		return handleSQSEvent(ctx, sqsEvent, s3client, sqsclient)
+	}, nil))
+}
+
+func buildClients(cfg aws.Config) (S3API, SQSAPI, error) {
+	s3svc := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = env.UsePathStyleS3Opt
+	})
+
+	log.Debug(logger, "Created S3 client", "client", s3svc)
+
+	var sqsResolver sqs.EndpointResolverFunc = func(region string, options sqs.EndpointResolverOptions) (aws.Endpoint, error) {
+		return cfg.EndpointResolverWithOptions.ResolveEndpoint("sqs", cfg.Region)
+	}
+	sqssvc := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+		// the logic in internal/awsHelpers/config doesn't affect the endpoint for SQS, and this is
+		// needed so that localstack will work
+		if _, isSet := os.LookupEnv("LOCALSTACK_HOSTNAME"); isSet {
+			o.EndpointResolver = sqsResolver
+		}
+	})
+
+	log.Debug(logger, "Created SQS client", "client", sqssvc)
+
+	return s3svc, sqssvc, nil
 
 }

--- a/cmd/EnqueueFFISDownload/handler.go
+++ b/cmd/EnqueueFFISDownload/handler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -16,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/usdigitalresponse/grants-ingest/internal/log"
+	ffis "github.com/usdigitalresponse/grants-ingest/pkg/grantsSchemas/ffis"
 )
 
 type SQSAPI interface {
@@ -38,7 +40,8 @@ var (
 )
 
 func handleS3Event(ctx context.Context, s3Event events.S3Event, s3client S3API, sqsclient SQSAPI) error {
-	emailBody, err := getEmailFromS3Event(s3client, s3Event, ctx)
+	uploadedFile := s3Event.Records[0].S3.Object.Key
+	emailBody, err := getEmailFromS3Event(ctx, s3client, s3Event, uploadedFile)
 	if err != nil {
 		return log.Errorf(logger, "Error reading email from S3", err)
 	}
@@ -56,7 +59,7 @@ func handleS3Event(ctx context.Context, s3Event events.S3Event, s3client S3API, 
 	log.Info(logger, "Parsed URL from email body", "url", url)
 
 	// Enqueue the URL for download
-	err = enqueueURLForDownload(ctx, url, sqsclient)
+	err = enqueueURLForDownload(ctx, sqsclient, url, uploadedFile)
 	if err != nil {
 		return log.Errorf(logger, "Failed to enqueue parsed URL", err)
 	}
@@ -109,11 +112,21 @@ func parseURLFromEmailBody(plaintext string) (string, error) {
 	return matches[0], nil
 }
 
-func enqueueURLForDownload(ctx context.Context, url string, client SQSAPI) error {
+func enqueueURLForDownload(ctx context.Context, client SQSAPI, url string, fileKey string) error {
+	messageObj := ffis.FFISMessageDownload{
+		DownloadURL:   url,
+		SourceFileKey: fileKey,
+	}
+	serializedMessage, err := json.Marshal(messageObj)
+	if err != nil {
+		return err
+	}
+
 	message := sqs.SendMessageInput{
-		MessageBody: aws.String(url),
+		MessageBody: aws.String(string(serializedMessage)),
 		QueueUrl:    aws.String(env.DestinationQueueURL),
 	}
+
 	output, err := client.SendMessage(ctx, &message)
 
 	if err != nil {
@@ -123,15 +136,15 @@ func enqueueURLForDownload(ctx context.Context, url string, client SQSAPI) error
 	return nil
 }
 
-func getEmailFromS3Event(s3client S3API, s3Event events.S3Event, ctx context.Context) (io.ReadCloser, error) {
+func getEmailFromS3Event(ctx context.Context, s3client S3API, s3Event events.S3Event, uploadedFileName string) (io.ReadCloser, error) {
 	bucket := s3Event.Records[0].S3.Bucket.Name
-	uploadedFile := s3Event.Records[0].S3.Object.Key
-	logger := log.With(logger, "bucket", bucket, "key", uploadedFile)
+
+	logger := log.With(logger, "bucket", bucket, "key", uploadedFileName)
 	log.Debug(logger, "Reading from bucket")
 	// Get the email body
 	resp, err := s3client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
-		Key:    aws.String(uploadedFile),
+		Key:    aws.String(uploadedFileName),
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/EnqueueFFISDownload/handler_test.go
+++ b/cmd/EnqueueFFISDownload/handler_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/go-kit/log"
+	ffis "github.com/usdigitalresponse/grants-ingest/pkg/grantsSchemas/ffis"
 )
 
 type MockS3 struct {
@@ -64,6 +66,7 @@ func TestHandleS3Event(t *testing.T) {
 			}
 			mocks3, mocksqs := getMockClients()
 			mocks3.content = string(content)
+			s3FileKey := "test/email/file.eml"
 			ctx := context.Background()
 			s3Event := events.S3Event{
 				Records: []events.S3EventRecord{
@@ -73,7 +76,7 @@ func TestHandleS3Event(t *testing.T) {
 								Name: "test-bucket",
 							},
 							Object: events.S3Object{
-								Key: "test/email/file.eml",
+								Key: s3FileKey,
 							},
 						},
 					},
@@ -83,11 +86,19 @@ func TestHandleS3Event(t *testing.T) {
 			err = handleS3Event(ctx, s3Event, mocks3, mocksqs)
 
 			if test.expectedURL != "" {
+				var message ffis.FFISMessageDownload
 				if err != nil {
 					t.Errorf("Error parsing S3 event: %v", err)
 				}
-				if *mocksqs.message != test.expectedURL {
-					t.Errorf("Expected message %v, got %v", test.expectedURL, mocksqs.message)
+				err = json.Unmarshal([]byte(*mocksqs.message), &message)
+				if err != nil {
+					t.Errorf("Error parsing SQS message: %v", err)
+				}
+				if message.DownloadURL != test.expectedURL {
+					t.Errorf("Expected message %v, got %v", test.expectedURL, message.DownloadURL)
+				}
+				if message.SourceFileKey != s3FileKey {
+					t.Errorf("Expected message %v, got %v", s3FileKey, message.SourceFileKey)
 				}
 			} else {
 				// parse expected bad message

--- a/pkg/grantsSchemas/ffis/types.go
+++ b/pkg/grantsSchemas/ffis/types.go
@@ -1,0 +1,7 @@
+package ffis
+
+// message payload for FFIS download operations
+type FFISMessageDownload struct {
+	SourceFileKey string `json:"sourceFileKey"`
+	DownloadURL   string `json:"downloadUrl"`
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -423,3 +423,26 @@ module "EnqueueFFISDownload" {
     aws_sqs_queue.ffis_downloads,
   ]
 }
+
+module "DownloadFFISSpreadsheet" {
+  source                                       = "./modules/DownloadFFISSpreadsheet"
+  namespace                                    = var.namespace
+  function_name                                = "DownloadFFISSpreadsheet"
+  permissions_boundary_arn                     = local.permissions_boundary_arn
+  lambda_artifact_bucket                       = module.lambda_artifacts_bucket.bucket_id
+  log_retention_in_days                        = var.lambda_default_log_retention_in_days
+  log_level                                    = var.lambda_default_log_level
+  lambda_code_path                             = local.lambda_code_path
+  lambda_arch                                  = var.lambda_arch
+  additional_environment_variables             = local.lambda_environment_variables
+  additional_lambda_execution_policy_documents = local.lambda_execution_policies
+  lambda_layer_arns                            = local.lambda_layer_arns
+
+  source_queue_name                            = aws_sqs_queue.ffis_downloads.name
+  download_target_bucket_name                  = module.grants_source_data_bucket.bucket_id
+
+  depends_on = [
+    module.grants_source_data_bucket,
+    aws_sqs_queue.ffis_downloads,
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -438,8 +438,8 @@ module "DownloadFFISSpreadsheet" {
   additional_lambda_execution_policy_documents = local.lambda_execution_policies
   lambda_layer_arns                            = local.lambda_layer_arns
 
-  source_queue_name                            = aws_sqs_queue.ffis_downloads.name
-  download_target_bucket_name                  = module.grants_source_data_bucket.bucket_id
+  source_queue_name           = aws_sqs_queue.ffis_downloads.name
+  download_target_bucket_name = module.grants_source_data_bucket.bucket_id
 
   depends_on = [
     module.grants_source_data_bucket,

--- a/terraform/modules/DownloadFFISSpreadsheet/main.tf
+++ b/terraform/modules/DownloadFFISSpreadsheet/main.tf
@@ -83,7 +83,7 @@ module "lambda_function" {
   memory_size = 128
   environment_variables = merge(var.additional_environment_variables, {
     DD_TAGS            = join(",", sort([for k, v in local.dd_tags : "${k}:${v}"]))
-    TARGET_BUCKET_NAME = data.aws_sqs_queue.ffis_downloads.id
+    TARGET_BUCKET_NAME = data.aws_s3_bucket.download_target.id
     LOG_LEVEL          = var.log_level
     S3_USE_PATH_STYLE  = "true"
   })

--- a/terraform/modules/DownloadFFISSpreadsheet/main.tf
+++ b/terraform/modules/DownloadFFISSpreadsheet/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_version = "1.3.9"
+  required_providers {
+    aws = "~> 4.55.0"
+  }
+}
+
+locals {
+  dd_tags = merge(
+    {
+      for item in compact(split(",", try(var.additional_environment_variables.DD_TAGS, ""))) :
+      split(":", trimspace(item))[0] => try(split(":", trimspace(item))[1], "")
+    },
+    var.datadog_custom_tags,
+    { handlername = lower(var.function_name), },
+  )
+}
+
+data "aws_s3_bucket" "download_target" {
+  bucket = var.download_target_bucket_name
+}
+
+data "aws_sqs_queue" "ffis_downloads" {
+  name = var.source_queue_name
+}
+
+module "lambda_execution_policy" {
+  source  = "cloudposse/iam-policy/aws"
+  version = "0.4.0"
+
+  iam_source_policy_documents = var.additional_lambda_execution_policy_documents
+  iam_policy_statements = {
+    AllowS3DownloadWrite = {
+      effect  = "Allow"
+      actions = ["s3:PutObject"]
+      resources = [
+        # Path: /sources/YYYY/mm/dd/ffis/download.xlsx
+        "${data.aws_s3_bucket.download_target.arn}/sources/*/*/*/ffis/download.xlsx"
+      ]
+    }
+    AllowSQSGet = {
+      effect  = "Allow"
+      actions = ["sqs:ReceiveMessage"]
+      resources = [
+        data.aws_sqs_queue.ffis_downloads.arn,
+      ]
+    }
+  }
+}
+
+module "lambda_function" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "4.12.1"
+
+  function_name = "${var.namespace}-${var.function_name}"
+  description   = "Downloads FFIS XLSX files and saves to S3"
+
+  role_permissions_boundary         = var.permissions_boundary_arn
+  attach_cloudwatch_logs_policy     = true
+  cloudwatch_logs_retention_in_days = var.log_retention_in_days
+  attach_policy_json                = true
+  policy_json                       = module.lambda_execution_policy.json
+
+  handler       = "bootstrap"
+  runtime       = "provided.al2"
+  architectures = [var.lambda_arch]
+  publish       = true
+  layers        = var.lambda_layer_arns
+
+  source_path = [{
+    path = var.lambda_code_path
+    commands = [
+      "task build-DownloadFFISSpreadsheet",
+      "cd bin/DownloadFFISSpreadsheet",
+      ":zip",
+    ],
+  }]
+  store_on_s3               = true
+  s3_bucket                 = var.lambda_artifact_bucket
+  s3_server_side_encryption = "AES256"
+
+  timeout     = 30 # seconds
+  memory_size = 128
+  environment_variables = merge(var.additional_environment_variables, {
+    DD_TAGS            = join(",", sort([for k, v in local.dd_tags : "${k}:${v}"]))
+    FFIS_SQS_QUEUE_URL = data.aws_sqs_queue.ffis_downloads.id
+    LOG_LEVEL          = var.log_level
+    S3_USE_PATH_STYLE  = "true"
+  })
+
+  allowed_triggers = {
+    SQSQueueNotification = {
+      sqs_queue_arn = data.aws_sqs_queue.ffis_downloads.arn
+      batch_size    = 1
+    }
+  }
+}

--- a/terraform/modules/DownloadFFISSpreadsheet/main.tf
+++ b/terraform/modules/DownloadFFISSpreadsheet/main.tf
@@ -90,10 +90,10 @@ module "lambda_function" {
 
   event_source_mapping = {
     sqs = {
-      enabled = true
-      batch_size = 1
+      enabled                            = true
+      batch_size                         = 1
       maximum_batching_window_in_seconds = 20
-      event_source_arn = data.aws_sqs_queue.ffis_downloads.arn
+      event_source_arn                   = data.aws_sqs_queue.ffis_downloads.arn
       scaling_config = {
         maximum_concurrency = 1
       }

--- a/terraform/modules/DownloadFFISSpreadsheet/output.tf
+++ b/terraform/modules/DownloadFFISSpreadsheet/output.tf
@@ -1,0 +1,27 @@
+output "lambda_function_name" {
+  value = module.lambda_function.lambda_function_name
+}
+
+output "lambda_function_arn" {
+  value = module.lambda_function.lambda_function_arn
+}
+
+output "lambda_function_qualified_arn" {
+  value = module.lambda_function.lambda_function_qualified_arn
+}
+
+output "lambda_function_source_artifact_object_key" {
+  value = module.lambda_function.s3_object.key
+}
+
+output "lambda_function_source_artifact_object_version_id" {
+  value = module.lambda_function.s3_object.version_id
+}
+
+output "lambda_function_log_group_name" {
+  value = module.lambda_function.lambda_cloudwatch_log_group_name
+}
+
+output "lambda_function_log_group_arn" {
+  value = module.lambda_function.lambda_cloudwatch_log_group_arn
+}

--- a/terraform/modules/DownloadFFISSpreadsheet/variables.tf
+++ b/terraform/modules/DownloadFFISSpreadsheet/variables.tf
@@ -1,0 +1,84 @@
+// Common
+variable "namespace" {
+  type        = string
+  description = "Prefix to use for resource names and identifiers."
+}
+
+variable "function_name" {
+  description = "Name of this Lambda function (excluding namespace prefix)."
+  type        = string
+}
+
+variable "permissions_boundary_arn" {
+  description = "ARN of the IAM policy to apply as a permissions boundary when provisioning a new role. Ignored if `role_arn` is null."
+  type        = string
+  default     = null
+}
+
+variable "lambda_layer_arns" {
+  description = "Lambda layer ARNs to attach to the function."
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_artifact_bucket" {
+  description = "Name of the S3 bucket used to store Lambda source artifacts."
+  type        = string
+}
+
+variable "lambda_code_path" {
+  description = "Path to the local directory containing lambda code."
+  type        = string
+}
+
+variable "lambda_arch" {
+  description = "The target build architecture for Lambda functions (either x86_64 or arm64)."
+  type        = string
+
+  validation {
+    condition     = var.lambda_arch == "x86_64" || var.lambda_arch == "arm64"
+    error_message = "Architecture must be x86_64 or arm64."
+  }
+}
+
+variable "log_level" {
+  description = "Value for the LOG_LEVEL environment variable."
+  type        = string
+  default     = "INFO"
+}
+
+variable "log_retention_in_days" {
+  description = "Number of days to retain logs."
+  type        = number
+  default     = 30
+}
+
+variable "additional_lambda_execution_policy_documents" {
+  description = "JSON policy document(s) containing permissions to configure for the Lambda function, in addition to any defined by this module."
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_environment_variables" {
+  description = "Environment variables to configure for the Lambda function, in addition to any defined by this module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "datadog_custom_tags" {
+  description = "Custom tags to configure on the DD_TAGS environment variable."
+  type        = map(string)
+  default     = {}
+}
+
+// Module-specific
+
+variable "source_queue_name" {
+  description = "Name of the SQS queue with files to be downloaded."
+  type        = string
+}
+
+variable "download_target_bucket_name" {
+  description = "Name of the S3 bucket used to write downloaded files."
+  type        = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,5 +10,7 @@ output "lambda_functions" {
   value = [
     module.DownloadGrantsGovDB.lambda_function_name,
     module.SplitGrantsGovXMLDB.lambda_function_name,
+    module.EnqueueFFISDownload.lambda_function_name,
+    module.DownloadFFISSpreadsheet.lambda_function_name,
   ]
 }


### PR DESCRIPTION
### Ticket #11
Closes #11

## Description
- New DownloadFFISSpreadsheet lambda function
- Invoked via message populated by EnqueueFFISDownload queue. 
- Given the download from the source email, writes content to target at same prefix with `download.xlsx` per ticket description.

## Testing  
1. Launch localstack, apply with `tflocal apply -var-file=local.tfvars  -auto-approve`
2. Enqueue a message for download
    a. Option 1, create a fake EML file - `awslocal s3 cp ../cmd/EnqueueFFISDownload/fixtures/good.eml s3://grants-ingest-grantssourcedata-000000000000-us-west-2/sources/2023/05/02/ffis/raw.eml`. Note that `good.eml` must be edited first to include a valid link!
    b. Option 2, populate the queue directly - `awslocal sqs send-message --queue-url http://localhost:4566/000000000000/ffis_downloads --message-body "{\"sourceFileKey\":\"sources/2023/05/02/ffis/raw.eml\",\"downloadUrl\":\"https://go.microsoft.com/fwlink/?LinkID=521962\"}"`
3. Once it's processed successfully (see `awslocal logs tail /aws/lambda/grants-ingest-DownloadFFISSpreadsheet`), assuming localstack is setup and mapped to localhost, the file should be downloadable from `http://grants-ingest-grantssourcedata-000000000000-us-west-2.s3.localstack.localhost:4566/sources/2023/05/02/ffis/download.xlsx`

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
