### PR TITLE
FIX: Specify SQS principal in Lambda trigger

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -59,6 +59,8 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           version: 3.x
+      - name: Pre-build
+        run: task build
       - name: Get project TF version
         id: get_version
         run: echo "TF_VERSION=$(cat .terraform-version | tr -d '[:space:]')" | tee -a $GITHUB_OUTPUT

--- a/terraform/modules/DownloadFFISSpreadsheet/main.tf
+++ b/terraform/modules/DownloadFFISSpreadsheet/main.tf
@@ -102,6 +102,7 @@ module "lambda_function" {
 
   allowed_triggers = {
     SQSQueueNotification = {
+      principal     = "sqs.amazonaws.com"
       sqs_queue_arn = data.aws_sqs_queue.ffis_downloads.arn
       batch_size    = 1
     }


### PR DESCRIPTION
### Ticket #11 

## Description

Provides an explicit `principal` identifier for the SQS service in the Lambda triggers introduced in #73, which is causing Terraform to [fail](https://github.com/usdigitalresponse/grants-ingest/actions/runs/4918444417/jobs/8785188238) with errors like:
```
Error: adding Lambda Permission (grants_ingest-staging-DownloadFFISSpreadsheet/SQSQueueNotification): InvalidParameterValueException: The provided principal was invalid. Please check the principal and try again.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "bdac311b-8683-4904-b517-ab7a4e7fac7d"
  },
  Message_: "The provided principal was invalid. Please check the principal and try again.",
  Type: "User"
}

  with module.DownloadFFISSpreadsheet.module.lambda_function.aws_lambda_permission.current_version_triggers["SQSQueueNotification"],
  on .terraform/modules/DownloadFFISSpreadsheet.lambda_function/main.tf line 236, in resource "aws_lambda_permission" "current_version_triggers":
 236: resource "aws_lambda_permission" "current_version_triggers" {
```

**Additionally,** I'm using this PR to shim in a potential optimization to the "Build and Deploy" GHA workflow. Prior to this change, Go dependencies first get installed in the workflow during `terraform apply`, which (indirectly) runs `go build` for each individual Lambda function. Since these builds take place in separate processes, the deployment pipeline spends time re-installing/-building common dependencies. My theory is that by running `go build` across the entire project first, we can allow the Go toolchain to optimize the installation/build steps, which will hopefully result in a reduced cumulative duration for deploying all Lambdas.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [x] Added PR reviewers
