### PR TITLE
Fix: Instrument AWS config before first use

### DIFF
--- a/cmd/PersistGrantsGovXMLDB/main.go
+++ b/cmd/PersistGrantsGovXMLDB/main.go
@@ -49,6 +49,7 @@ func main() {
 		if err != nil {
 			return fmt.Errorf("could not create AWS SDK config: %w", err)
 		}
+		awstrace.AppendMiddleware(&cfg)
 
 		// Configure service clients
 		s3Svc := s3.NewFromConfig(cfg, func(o *s3.Options) {
@@ -56,7 +57,6 @@ func main() {
 		})
 		dynamodbSvc := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {})
 
-		awstrace.AppendMiddleware(&cfg)
 		log.Debug(logger, "Starting Lambda")
 		return handleS3EventWithConfig(s3Svc, dynamodbSvc, ctx, s3Event)
 	}, nil))


### PR DESCRIPTION
### Ticket #110 

Fixes #110

## Description

This is a teeny tiny PR that moves the `awstrace.AppendMiddleware()` call in the `PersistGrantsGovXMLDB` handler's startup steps so that it's called a bit earlier – specifically, before the `aws.Config` value is passed to any AWS service clients. This is necessary because the Datadog `awstrace` behavior modifies the config value in order to auto-instrument tracing, and those modifications need to be present before it is used (copied) to configure individual clients.

## Testing

Not much to do here since it's not quite possible to test Datadog locally. Tests (automated and manual) appear to be working just fine, and Lambda handlers' `main()` functions don't execute during unit tests.

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [X] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
