### PR TITLE
Enhancement: Follow up to #284

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,3 +231,9 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ env.REPORT_CONTENT }}
           edit-mode: replace
+      - name: Print zip md5s
+        if: always()
+        run: md5sum builds/*
+      - name: Print bin md5s
+        if: always()
+        run: md5sum ../bin/*/*

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,7 +96,7 @@ tasks:
       GOPATH:
         sh: go env GOPATH
     cmds:
-      - go build -gcflags="-trimpath=$GOPATH" -asmflags="-trimpath=$GOPATH" -trimpath -v -o {{ .BUILD_BIN }} ./cli/grants-ingest
+      - go build -gcflags="-trimpath=$GOPATH" -asmflags="-trimpath=$GOPATH" -trimpath -ldflags=-buildid= -v -o {{ .BUILD_BIN }} ./cli/grants-ingest
       - cmd: echo {{ .BUILD_BIN }}
         silent: true
     sources:
@@ -152,7 +152,7 @@ tasks:
       GOPATH:
         sh: go env GOPATH
     cmds:
-      - GOOS=linux GOARCH=arm64 go build -gcflags="-trimpath=$GOPATH" -ldflags="-s -w" -asmflags="-trimpath=$GOPATH" -trimpath -tags "lambda.norpc" -v -o {{ .BUILD_DEST }} {{ .SOURCE }}
+      - GOOS=linux GOARCH=arm64 go build -gcflags="-trimpath=$GOPATH" -ldflags="-s -w" -asmflags="-trimpath=$GOPATH" -trimpath -ldflags=-buildid= -tags "lambda.norpc" -v -o {{ .BUILD_DEST }} {{ .SOURCE }}
 
   build:
     desc: "Compiles all Lambda handlers"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,7 +96,7 @@ tasks:
       GOPATH:
         sh: go env GOPATH
     cmds:
-      - go build -gcflags="-trimpath=$GOPATH" -asmflags="-trimpath=$GOPATH" -trimpath -ldflags=-buildid= -v -o {{ .BUILD_BIN }} ./cli/grants-ingest
+      - go build -gcflags="-trimpath=$GOPATH" -asmflags="-trimpath=$GOPATH" -trimpath -ldflags=-buildid= -buildvcs=false -v -o {{ .BUILD_BIN }} ./cli/grants-ingest
       - cmd: echo {{ .BUILD_BIN }}
         silent: true
     sources:
@@ -152,7 +152,7 @@ tasks:
       GOPATH:
         sh: go env GOPATH
     cmds:
-      - GOOS=linux GOARCH=arm64 go build -gcflags="-trimpath=$GOPATH" -ldflags="-s -w" -asmflags="-trimpath=$GOPATH" -trimpath -ldflags=-buildid= -tags "lambda.norpc" -v -o {{ .BUILD_DEST }} {{ .SOURCE }}
+      - GOOS=linux GOARCH=arm64 go build -gcflags="-trimpath=$GOPATH" -ldflags="-s -w" -asmflags="-trimpath=$GOPATH" -trimpath -ldflags=-buildid= -buildvcs=false -tags "lambda.norpc" -v -o {{ .BUILD_DEST }} {{ .SOURCE }}
 
   build:
     desc: "Compiles all Lambda handlers"


### PR DESCRIPTION
### Resolves #66 

This PR is a follow up to #284 and resolve additional caveats to ensuring build reproducibility. Specifically, it modifies `go build` options to string build-time metadata (including VCS information about the current environment, which is pretty much guaranteed to differ across CI/CD workflow executions) from compiled output.

Clarifying note: This PR avoids redundant build-and-upload operations in related to Lambda artifacts stored in S3 **during CI/CD**. The previous PR for the same issue, #284, resolved the issue for scenarios where `terraform plan` and/or `terraform apply` were executed in a **local environment** (in all cases except for possibly when git state had changed), and still constitutes an overall (if insufficient) improvement.

## Testing

To verify that the new changes do produce identical binaries, you can check the MD5 checksums outputted by the `Validate and Plan Terraform` job for 1194dda94f191bdd6d9f8b92a8fefe2fe4332bb2 and its subsequent commit, 34707d6754761e071d51c0cd9d5abda907f2ffdb, neither of which contained changes to go source code:

1. [Output #409](https://github.com/usdigitalresponse/grants-ingest/actions/runs/5935041001/job/16092848623?pr=291) for 1194dda94f191bdd6d9f8b92a8fefe2fe4332bb2:
    ```shell
    # Note: working directory is terraform/
    $ md5sum builds/*
      7c8ba3b50a9afa37f3d5ded9a84abafc  builds/DownloadFFISSpreadsheet.zip
      50e41ca557163f2b9a9ea7670d2d6683  builds/DownloadGrantsGovDB.zip
      d4709bb26dac5010aa4eace7502a9bd9  builds/EnqueueFFISDownload.zip
      02bd40089ce5a3394cb37289d30a8b38  builds/ExtractGrantsGovDBToXML.zip
      140f86d746b01fcc69f4397efe5a7ade  builds/PersistFFISData.zip
      439181ee23896a1cacf65fa4a85001e5  builds/PersistGrantsGovXMLDB.zip
      e238d67556f297623a6f9baada343031  builds/PublishGrantEvents.zip
      17830ddb0b97c7e57333bb8e676187da  builds/ReceiveFFISEmail.zip
      28aba2012e846186e4bdca67871c879a  builds/SplitFFISSpreadsheet.zip
      29ea660c3813730ea2f41d6168439638  builds/SplitGrantsGovXMLDB.zip
    $ md5sum ../bin/*/*
      70277484a905bf6d0022c7f9e1554b6d  ../bin/DownloadFFISSpreadsheet/bootstrap
      ddc4e0ad418bbeb526ca5036aa7b5778  ../bin/DownloadGrantsGovDB/bootstrap
      bcabbae64e5747a6b453a8c89202b23b  ../bin/EnqueueFFISDownload/bootstrap
      b69f44abc713f5d98aa4515ed7b17f88  ../bin/ExtractGrantsGovDBToXML/bootstrap
      b72bb6252f902b72ac446a20138675b5  ../bin/PersistFFISData/bootstrap
      3504f6da3d7ac9302b2ef416215ab428  ../bin/PersistGrantsGovXMLDB/bootstrap
      fa0e8e767c1403b9c3ca652bfe293c91  ../bin/PublishGrantEvents/bootstrap
      2c0f2c4ab23cae76847c456916eb352a  ../bin/ReceiveFFISEmail/bootstrap
      7a02071a72b6057c83187a3af18a1a37  ../bin/SplitFFISSpreadsheet/bootstrap
      c59522b04a4214bc2cc3822b593f5adb  ../bin/SplitGrantsGovXMLDB/bootstrap
    ```
2. [Output #410](https://github.com/usdigitalresponse/grants-ingest/actions/runs/5935071793/job/16092930858?pr=291) for 34707d6754761e071d51c0cd9d5abda907f2ffdb (identical to above):
    ```shell
    # Note: working directory is terraform/
    $ md5sum builds/*
      7c8ba3b50a9afa37f3d5ded9a84abafc  builds/DownloadFFISSpreadsheet.zip
      50e41ca557163f2b9a9ea7670d2d6683  builds/DownloadGrantsGovDB.zip
      d4709bb26dac5010aa4eace7502a9bd9  builds/EnqueueFFISDownload.zip
      02bd40089ce5a3394cb37289d30a8b38  builds/ExtractGrantsGovDBToXML.zip
      140f86d746b01fcc69f4397efe5a7ade  builds/PersistFFISData.zip
      439181ee23896a1cacf65fa4a85001e5  builds/PersistGrantsGovXMLDB.zip
      e238d67556f297623a6f9baada343031  builds/PublishGrantEvents.zip
      17830ddb0b97c7e57333bb8e676187da  builds/ReceiveFFISEmail.zip
      28aba2012e846186e4bdca67871c879a  builds/SplitFFISSpreadsheet.zip
      29ea660c3813730ea2f41d6168439638  builds/SplitGrantsGovXMLDB.zip
    $ md5sum ../bin/*/*
      70277484a905bf6d0022c7f9e1554b6d  ../bin/DownloadFFISSpreadsheet/bootstrap
      ddc4e0ad418bbeb526ca5036aa7b5778  ../bin/DownloadGrantsGovDB/bootstrap
      bcabbae64e5747a6b453a8c89202b23b  ../bin/EnqueueFFISDownload/bootstrap
      b69f44abc713f5d98aa4515ed7b17f88  ../bin/ExtractGrantsGovDBToXML/bootstrap
      b72bb6252f902b72ac446a20138675b5  ../bin/PersistFFISData/bootstrap
      3504f6da3d7ac9302b2ef416215ab428  ../bin/PersistGrantsGovXMLDB/bootstrap
      fa0e8e767c1403b9c3ca652bfe293c91  ../bin/PublishGrantEvents/bootstrap
      2c0f2c4ab23cae76847c456916eb352a  ../bin/ReceiveFFISEmail/bootstrap
      7a02071a72b6057c83187a3af18a1a37  ../bin/SplitFFISSpreadsheet/bootstrap
      c59522b04a4214bc2cc3822b593f5adb  ../bin/SplitGrantsGovXMLDB/bootstrap
    ```