### PR TITLE
#293: Add "Deploy to Production" workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,10 +1,12 @@
 name: Deploy to Production
 
 on:
-  release:
+  push:
+    tags:
+      release/**
 
 concurrency:
-  group: run_terraform-prod
+  group: production
   cancel-in-progress: false
 
 permissions:
@@ -12,13 +14,156 @@ permissions:
   id-token: write
 
 jobs:
-  build_and_deploy:
-    name: Build and Deploy to Production
-    uses: "./.github/workflows/build-and-deploy.yml"
-    with:
-      tf_backend_config_file: prod.s3.tfbackend
-      tf_var_file: prod.tfvars
-    secrets:
-      AWS_ROLE_TO_ASSUME: "${{ secrets.PRODUCTION_ROLE_ARN }}"
-      DATADOG_API_KEY: "${{ secrets.DATADOG_API_KEY }}"
-      DATADOG_APP_KEY: "${{ secrets.DATADOG_APP_KEY }}"
+  plan:
+    name: Plan Deployment
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    outputs:
+      terraform_plan_exitcode: ${{ steps.terraform_plan.outputs.exitcode }}
+    env:
+      TF_CLI_ARGS: "-no-color"
+      TF_INPUT: 0
+      TF_VAR_version_identifier: ${{ github.ref_name }}
+      TF_VAR_git_commit_sha: ${{ github.sha }}
+      TF_VAR_datadog_api_key: ${{ secrets.DATADOG_API_KEY }}
+      TF_VAR_datadog_app_key: ${{ secrets.DATADOG_APP_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          go-version-file: go.mod
+      - name: Install Taskfile
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+      - name: Pre-plan build optimizations
+        run: |
+          task prebuild-lambda
+          task build
+      - name: Get project TF version
+        id: get_version
+        run: echo "TF_VERSION=$(cat .terraform-version | tr -d '[:space:]')" | tee -a $GITHUB_OUTPUT
+        working-directory: terraform
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: true
+          terraform_version: ${{ steps.get_version.outputs.TF_VERSION }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-west-2
+          role-to-assume: "${{ secrets.PRODUCTION_ROLE_ARN }}"
+      - name: Terraform Init
+        run: terraform init -backend-config="production.s3.tfbackend"
+      - name: Terraform Plan
+        id: terraform_plan
+        run: terraform plan -var-file="prod.tfvars" -out="tfplan" -detailed-exitcode
+      - name: Generate plaintext plan
+        id: show_plan
+        run: terraform show tfplan
+      - name: Reformat plan
+        run: |
+          echo '${{ steps.show_plan.outputs.stdout || steps.show_plan.outputs.stderr }}' \
+            | sed -E 's/^([[:space:]]+)([-+])/\2\1/g' > plan.txt
+          PLAN=$(cat plan.txt | head -c 65300)
+          echo "PLAN<<EOF" >> $GITHUB_ENV
+          echo "$PLAN" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Write the step summary
+        run: |
+          REPORT_FILE=$(mktemp -t summary.md.XXXXX )
+          echo "REPORT_FILE=$REPORT_FILE" >> $GITHUB_ENV
+          cat >> $REPORT_FILE << 'ENDOFREPORT'
+          ## Terraform Plan Result
+
+          <details>
+          <summary>Output</summary>
+
+          ```diff
+          ${{ env.PLAN }}
+          ```
+
+          </details>
+          ENDOFREPORT
+          cat $REPORT_FILE >> $GITHUB_STEP_SUMMARY
+      - name: Encrypt terraform plan file
+        env:
+          PASSPHRASE: ${{ secrets.TFPLAN_SECRET }}
+        run: |
+          echo "$PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 -c --cipher-algo AES256 tfplan
+          rm tfplan
+      - name: Store terraform artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: terraform-${{ github.sha }}
+          path: |
+            ${{ github.workspace }}/terraform
+            !${{ github.workspace }}/terraform/.terraform
+      - name: Store executable artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bin-${{ github.sha }}
+          path: ${{ github.workspace }}/bin
+
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    environment: production
+    needs:
+      - plan
+    if: always() && needs.plan.outputs.terraform_plan_exitcode == 2
+    defaults:
+      run:
+        working-directory: terraform
+    env:
+      TF_CLI_ARGS: "-no-color"
+      TF_INPUT: 0
+    steps:
+      - uses: hashicorp/setup-terraform@v2
+      - name: Restore terraform artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: terraform-${{ github.sha }}
+          path: ${{ github.workspace }}/terraform
+      - name: Restore executable artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bin-${{ github.sha }}
+          path: ${{ github.workspace }}/bin
+      - name: Decrypt terraform plan file
+        env:
+          GPG_PASSPHRASE: ${{ secrets.TFPLAN_SECRET }}
+        run: echo "$GPG_PASSPHRASE" | gpg -qd --batch --yes --passphrase-fd 0 -o tfplan tfplan.gpg
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-west-2
+          role-to-assume: "${{ secrets.PRODUCTION_ROLE_ARN }}"
+      - name: Terraform Init
+        run: terraform init -backend-config="production.s3.tfbackend"
+      - name: Terraform Apply
+        run: terraform apply tfplan
+
+  update_release:
+    name: Update release
+    runs-on: ubuntu-latest
+    needs:
+      - deploy
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get release notes
+        id: get
+        continue-on-error: true
+        run: gh release view $RELEASE_TAG --json body --jq .body > release_notes.md
+      - name: Add deployment history to release notes
+        if: always() && steps.get.outcome == 'success'
+        run: printf "\n\nSuccessfully deployed at $(date --iso-8601=seconds)\n" >> release_notes.md
+      - name: Update release notes and status
+        if: always() && steps.get.outcome == 'success'
+        run: gh release edit $RELEASE_TAG --draft=false --prerelease=false --latest --verify-tag -F release_notes.md


### PR DESCRIPTION
### Closes #293 

## Description

This PR implements a new GitHub actions workflow according to #293. It provides a mechanism for automating deployments to our Production environment on AWS by performing the following actions when a tag matching the `release/*` pattern is pushed:
1. Generates a Terraform plan (compiling necessary Lambda handler binaries along the way)
2. Publishes the plaintext plan as a workflow step summary for subsequent review
3. Waits for approval (assuming the `production` GitHub environment requires approval, which it does)
4. Applies the Terraform plan generated in Step 2 as long as the remote state matches the plan's expectations
5. Finds a release (if one exists) that matches the release tag and updates it with the deployment history, ensuring that the release is in a non-draft, non-pre-release state.

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
