### PR TITLE
Add terraform configuration for Production

### DIFF
--- a/terraform/production.s3.tfbackend
+++ b/terraform/production.s3.tfbackend
@@ -1,0 +1,5 @@
+region         = "us-west-2"
+bucket         = "729134339726-us-west-2-terraform"
+key            = "usdr/grants_ingest/prod/us-west-2/terraform.tfstate"
+dynamodb_table = "grantsingest-prod-terraform-lock"
+encrypt        = "true"

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,0 +1,9 @@
+namespace                             = "grants_ingest"
+environment                           = "production"
+ssm_deployment_parameters_path_prefix = "/grants_ingest/production/deploy-config"
+datadog_enabled                       = true
+lambda_default_log_retention_in_days  = 30
+lambda_default_log_level              = "INFO"
+datadog_draft                         = false
+datadog_monitors_enabled              = true
+ffis_ingest_email_address             = "ffis-ingest@grants.usdigitalresponse.org"


### PR DESCRIPTION
### Closes #296 

## Description

This PR creates the necessary terraform config files for targeting the service's Production environment on AWS. These files are very similar to the existing files that target Staging, except that no Datadog metric metadata is specified, since that happens only needs to happen once, and is already configured for Staging deployments.

## Testing

1. Cross fingers
2. ![image](https://j.gifs.com/7Lwo28.gif)

If things don't go as planned, it'll be okay – this is an initial service release with no existing downstream dependencies.


## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
