### PR TITLE
Feat: Update Datadog service dashboard

### DIFF
--- a/cmd/DownloadFFISSpreadsheet/handler.go
+++ b/cmd/DownloadFFISSpreadsheet/handler.go
@@ -63,6 +63,7 @@ func downloadFile(ctx context.Context, msg ffis.FFISMessageDownload, httpClient 
 		return nil, fmt.Errorf("error downloading file: %w", ErrDownloadFailed)
 	}
 	log.Debug(logger, "Downloaded file", "url", msg.DownloadURL)
+	sendMetric("source_size", float64(resp.ContentLength))
 	return resp.Body, nil
 }
 

--- a/cmd/DownloadFFISSpreadsheet/main.go
+++ b/cmd/DownloadFFISSpreadsheet/main.go
@@ -18,6 +18,7 @@ import (
 	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/usdigitalresponse/grants-ingest/internal/awsHelpers"
+	"github.com/usdigitalresponse/grants-ingest/internal/ddHelpers"
 	"github.com/usdigitalresponse/grants-ingest/internal/log"
 	awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go-v2/aws"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
@@ -32,9 +33,9 @@ type Environment struct {
 }
 
 var (
-	env    Environment
-	logger log.Logger
-	// sendMetric       = ddHelpers.NewMetricSender("DownloadFFISSpreadsheet", "source:grants.gov")
+	env        Environment
+	logger     log.Logger
+	sendMetric = ddHelpers.NewMetricSender("DownloadFFISSpreadsheet", "source:ffis.org")
 )
 
 func main() {

--- a/cmd/SplitFFISSpreadsheet/sheet.go
+++ b/cmd/SplitFFISSpreadsheet/sheet.go
@@ -123,7 +123,7 @@ rowLoop:
 			case 0:
 				if f, err := strconv.ParseFloat(strings.TrimRight(cell, "+"), 64); err != nil {
 					log.Warn(logger, "Error parsing CFDA", err)
-					sendMetric("spreadsheet.cell_parsing_errors", 1)
+					sendMetric("spreadsheet.cell_parsing_errors", 1, "target:CFDA")
 					continue
 				} else {
 					opportunity.CFDA = fmt.Sprintf("%06.3f", f)
@@ -142,7 +142,7 @@ rowLoop:
 				// If we can't parse the funding amount, just skip the column
 				if err != nil {
 					log.Warn(logger, "Error parsing estimated funding", "error", err)
-					sendMetric("spreadsheet.cell_parsing_errors", 1)
+					sendMetric("spreadsheet.cell_parsing_errors", 1, "target:EstimatedFunding")
 					continue
 				}
 				opportunity.EstimatedFunding = num
@@ -156,7 +156,7 @@ rowLoop:
 				cellAxis, err := excelize.CoordinatesToCellName(colIndex+1, rowIndex+1)
 				if err != nil {
 					log.Warn(logger, "Error parsing cell axis for grant ID", "error", err)
-					sendMetric("spreadsheet.cell_parsing_errors", 1)
+					sendMetric("spreadsheet.cell_parsing_errors", 1, "target:GrantID")
 					continue
 				}
 
@@ -164,7 +164,7 @@ rowLoop:
 				if err != nil {
 					// log this, it is not worth aborting the whole extraction for
 					log.Warn(logger, "Error getting cell hyperlink for grant ID", "error", err)
-					sendMetric("spreadsheet.cell_parsing_errors", 1)
+					sendMetric("spreadsheet.cell_parsing_errors", 1, "target:GrantID")
 					continue
 				}
 
@@ -174,7 +174,7 @@ rowLoop:
 					url, err := url.Parse(target)
 					if err != nil {
 						log.Warn(logger, "Error parsing link for grant ID", "error", err)
-						sendMetric("spreadsheet.cell_parsing_errors", 1)
+						sendMetric("spreadsheet.cell_parsing_errors", 1, "target:GrantID")
 						continue
 					}
 
@@ -182,7 +182,7 @@ rowLoop:
 					oppID, err := strconv.ParseInt(url.Query().Get("oppId"), 10, 64)
 					if err != nil {
 						log.Warn(logger, "Error parsing opportunity ID", "error", err)
-						sendMetric("spreadsheet.cell_parsing_errors", 1)
+						sendMetric("spreadsheet.cell_parsing_errors", 1, "target:GrantID")
 						continue
 					}
 
@@ -217,7 +217,7 @@ rowLoop:
 				if !dateParsed {
 					log.Warn(logger, "Could not parse DueDate according to any attempted layouts",
 						"attempted_layouts", dateLayouts, "raw_value", cell)
-					sendMetric("spreadsheet.cell_parsing_errors", 1)
+					sendMetric("spreadsheet.cell_parsing_errors", 1, "target:DueDate")
 					continue
 				}
 			case 13:

--- a/terraform/datadog_dashboard.tf
+++ b/terraform/datadog_dashboard.tf
@@ -1882,7 +1882,7 @@ resource "datadog_dashboard" "service_dashboard" {
 
       widget {
         timeseries_definition {
-          title          = "Cell Parsing Errors"
+          title          = "Cell Parsing Errors by Target Field"
           show_legend    = true
           legend_layout  = "horizontal"
           legend_columns = ["sum"]
@@ -1893,14 +1893,13 @@ resource "datadog_dashboard" "service_dashboard" {
             formula {
               formula_expression = "errors"
               style {
-                palette       = "warm"
-                palette_index = 5
+                palette = "warm"
               }
             }
             query {
               metric_query {
                 name  = "errors"
-                query = "sum:grants_ingest.SplitFFISSpreadsheet.spreadsheet.cell_parsing_errors{$env,$service,$version}.as_count()"
+                query = "sum:grants_ingest.SplitFFISSpreadsheet.spreadsheet.cell_parsing_errors{$env,$service,$version} by {target}.as_count()"
               }
             }
           }

--- a/terraform/datadog_dashboard.tf
+++ b/terraform/datadog_dashboard.tf
@@ -1501,7 +1501,8 @@ resource "datadog_dashboard" "service_dashboard" {
               formula_expression = "failed"
               alias              = "Failed"
               style {
-                palette = "warm"
+                palette       = "warm"
+                palette_index = 3
               }
             }
             query {
@@ -1515,7 +1516,8 @@ resource "datadog_dashboard" "service_dashboard" {
               formula_expression = "published"
               alias              = "Published"
               style {
-                palette = "cool"
+                palette       = "green"
+                palette_index = 3
               }
             }
             query {
@@ -1810,8 +1812,7 @@ resource "datadog_dashboard" "service_dashboard" {
               formula_expression = "records_created"
               alias              = "Created"
               style {
-                palette       = "classic"
-                palette_index = 4
+                palette = "classic"
               }
             }
             query {
@@ -1866,7 +1867,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "row_count"
-                query = "sum:grants_ingest.SplitFFISSpreadsheet.spreadsheet.row_count{$env,$service,$version}.as_count()"
+                query = "avg:grants_ingest.SplitFFISSpreadsheet.spreadsheet.row_count{$env,$service,$version}.as_count()"
               }
             }
           }
@@ -1892,7 +1893,8 @@ resource "datadog_dashboard" "service_dashboard" {
             formula {
               formula_expression = "errors"
               style {
-                palette = "warm"
+                palette       = "warm"
+                palette_index = 5
               }
             }
             query {

--- a/terraform/datadog_dashboard.tf
+++ b/terraform/datadog_dashboard.tf
@@ -1,5 +1,6 @@
 locals {
   datadog_draft_label = var.datadog_draft ? "(Draft - ${var.environment})" : ""
+  datadog_notes_dir   = "${path.module}/datadog_notes"
 }
 
 resource "datadog_dashboard" "service_dashboard" {
@@ -8,7 +9,7 @@ resource "datadog_dashboard" "service_dashboard" {
   title       = trimspace("Grants Ingest Service Dashboard ${local.datadog_draft_label}")
   description = "Dashboard for monitoring the Grants Ingest pipeline service."
   layout_type = "ordered"
-  reflow_type = "auto"
+  reflow_type = "fixed"
 
   template_variable {
     name     = "env"
@@ -29,6 +30,203 @@ resource "datadog_dashboard" "service_dashboard" {
     defaults = ["*"]
   }
 
+  // Service Summary
+  widget {
+    group_definition {
+      title       = "Service Summary"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        trace_service_definition {
+          title              = "Overview"
+          env                = "$env"
+          service            = "$service"
+          span_name          = "aws.lambda"
+          display_format     = "two_column"
+          size_format        = "large"
+          show_breakdown     = false
+          show_distribution  = false
+          show_errors        = true
+          show_hits          = true
+          show_latency       = false
+          show_resource_list = true
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 8
+          height = 6
+        }
+      }
+
+      widget {
+        manage_status_definition {
+          title               = "Monitors"
+          query               = "tag:($env AND $service)"
+          display_format      = "countsAndList"
+          color_preference    = "text"
+          hide_zero_counts    = true
+          show_priority       = false
+          show_last_triggered = true
+          sort                = "status,asc"
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 6
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 0
+      width  = 12
+      height = 6
+    }
+  }
+
+  // DownloadFFISSpreadsheet
+  widget {
+    group_definition {
+      title       = "DownloadFFISSpreadsheet"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Status"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "invoke_success"
+              alias              = "Succeeded"
+            }
+            query {
+              metric_query {
+                name  = "invoke_success"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:downloadffisspreadsheet}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_failure"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:downloadffisspreadsheet}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Duration"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "invoke_duration"
+              alias              = "Duration"
+            }
+            query {
+              metric_query {
+                name  = "invoke_duration"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:downloadffisspreadsheet}"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_timeout"
+              alias              = "Timeout"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_timeout"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:downloadffisspreadsheet}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "FFIS.org Spreadsheet File Size"
+          legend_layout  = "horizontal"
+          legend_columns = ["value"]
+          show_legend    = true
+
+          yaxis {
+            include_zero = false
+          }
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "size"
+              alias              = "Size"
+            }
+            query {
+              metric_query {
+                name  = "size"
+                query = "avg:grants_ingest.DownloadFFISSpreadsheet.source_size{$env,$service,$version}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 6
+      width  = 12
+      height = 3
+    }
+  }
+
+  // DownloadGrantsGovDB
   widget {
     group_definition {
       title       = "DownloadGrantsGovDB"
@@ -72,6 +270,12 @@ resource "datadog_dashboard" "service_dashboard" {
             }
           }
         }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
       }
 
       widget {
@@ -111,11 +315,17 @@ resource "datadog_dashboard" "service_dashboard" {
             }
           }
         }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
       }
 
       widget {
         timeseries_definition {
-          title          = "Source File Size"
+          title          = "Grants.gov DB Zip File Size"
           legend_layout  = "horizontal"
           legend_columns = ["value"]
           show_legend    = true
@@ -134,18 +344,31 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "size"
-                query = "avg:grants_ingest.DownloadGrantsGovDB.source_size{$env,$service,$version,handlername:downloadgrantsgovdb}"
+                query = "avg:grants_ingest.DownloadGrantsGovDB.source_size{$env,$service,$version}"
               }
             }
           }
         }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
       }
+    }
+    widget_layout {
+      x      = 0
+      y      = 9
+      width  = 12
+      height = 3
     }
   }
 
+  // EnqueueFFISDownload
   widget {
     group_definition {
-      title       = "SplitGrantsGovXMLDB"
+      title       = "EnqueueFFISDownload"
       show_title  = true
       layout_type = "ordered"
 
@@ -166,7 +389,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:enqueueffisdownload}.as_count()"
               }
             }
 
@@ -181,10 +404,16 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:enqueueffisdownload}.as_count()"
               }
             }
           }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
         }
       }
 
@@ -205,7 +434,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:splitgrantsgovxmldb}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:enqueueffisdownload}"
               }
             }
 
@@ -220,16 +449,23 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:splitgrantsgovxmldb}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:enqueueffisdownload}"
               }
             }
           }
         }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
       }
 
+      // Shows DLQ size
       widget {
         timeseries_definition {
-          title          = "Grant Opportunities Results"
+          title          = "Queue Size"
           show_legend    = true
           legend_layout  = "horizontal"
           legend_columns = ["sum"]
@@ -243,70 +479,34 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "records_skipped"
-              alias              = "Skipped"
-              style {
-                palette       = "cool"
-                palette_index = 4
-              }
+              formula_expression = "queue_size"
+              alias              = "Messages"
             }
             query {
               metric_query {
-                name  = "records_skipped"
-                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.skipped{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
-              }
-            }
-
-            formula {
-              formula_expression = "records_updated"
-              alias              = "Updated"
-              style {
-                palette       = "purple"
-                palette_index = 4
-              }
-            }
-            query {
-              metric_query {
-                name  = "records_updated"
-                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.updated{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
-              }
-            }
-
-            formula {
-              formula_expression = "records_created"
-              alias              = "Created"
-              style {
-                palette       = "classic"
-                palette_index = 4
-              }
-            }
-            query {
-              metric_query {
-                name  = "records_created"
-                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.created{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
-              }
-            }
-
-            formula {
-              formula_expression = "records_failed"
-              alias              = "Failed"
-              style {
-                palette       = "warm"
-                palette_index = 5
-              }
-            }
-            query {
-              metric_query {
-                name  = "records_failed"
-                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.failed{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
+                name  = "queue_size"
+                query = "sum:aws.sqs.approximate_number_of_messages_visible{$env,$service,$version,queuename:ffis_downloads}.as_count()"
               }
             }
           }
         }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
       }
+    }
+    widget_layout {
+      x      = 0
+      y      = 12
+      width  = 12
+      height = 3
     }
   }
 
+  // ExtractGrantsGovDBToXML
   widget {
     group_definition {
       title       = "ExtractGrantsGovDBToXML"
@@ -350,6 +550,12 @@ resource "datadog_dashboard" "service_dashboard" {
             }
           }
         }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
       }
 
       widget {
@@ -389,7 +595,1516 @@ resource "datadog_dashboard" "service_dashboard" {
             }
           }
         }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
       }
+
+      widget {
+        timeseries_definition {
+          title          = "Extraction Results"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "archives_downloaded"
+              alias              = "Zip Files Downloaded"
+              style {
+                palette       = "cool"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "archives_downloaded"
+                query = "sum:grants_ingest.ExtractGrantsGovDBToXML.archive.downloaded{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "xml_files_extracted"
+              alias              = "XML Files Extracted"
+              style {
+                palette       = "purple"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "xml_files_extracted"
+                query = "sum:grants_ingest.ExtractGrantsGovDBToXML.xml.extracted{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "xml_files_uploaded"
+              alias              = "XML Files Uploaded"
+              style {
+                palette       = "classic"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "xml_files_uploaded"
+                query = "sum:grants_ingest.ExtractGrantsGovDBToXML.xml.uploaded{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 15
+      width  = 12
+      height = 3
+    }
+  }
+
+  // PersistFFISData
+  widget {
+    group_definition {
+      title       = "PersistFFISData"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Status"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "invoke_success"
+              alias              = "Succeeded"
+            }
+            query {
+              metric_query {
+                name  = "invoke_success"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:persistffisdata}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_failure"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:persistffisdata}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Duration"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "invoke_duration"
+              alias              = "Duration"
+            }
+            query {
+              metric_query {
+                name  = "invoke_duration"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:persistffisdata}"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_timeout"
+              alias              = "Timeout"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_timeout"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:persistffisdata}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      // Shows counts of opportunities saved vs skipped due to being unmodified
+      widget {
+        timeseries_definition {
+          title          = "Opportunity Records Saved vs Skipped"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "records_saved"
+              alias              = "Saved"
+              style {
+                palette       = "cool"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_saved"
+                query = "sum:grants_ingest.PersistFFISData.opportunity.saved{$env,$service,$version}.as_count()"
+              }
+            }
+
+            // Derived skipped count by subtracting invocation errors and saved record counts
+            // from the total number of invocations.
+            formula {
+              formula_expression = "invocation_total - invocation_failure - records_saved"
+              alias              = "Skipped (Unmodified)"
+              style {
+                palette       = "warm"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_saved"
+                query = "sum:grants_ingest.PersistFFISData.opportunity.saved{$env,$service,$version}.as_count()"
+              }
+            }
+            query {
+              metric_query {
+                name  = "invocation_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:persistffisdata}.as_count()"
+              }
+            }
+            query {
+              metric_query {
+                name  = "invocation_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:persistffisdata}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 18
+      width  = 12
+      height = 3
+    }
+  }
+
+  // PersistGrantsGovXMLDB
+  widget {
+    group_definition {
+      title       = "PersistGrantsGovXMLDB"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Status"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "invoke_success"
+              alias              = "Succeeded"
+            }
+            query {
+              metric_query {
+                name  = "invoke_success"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:persistgrantsgovxmldb}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_failure"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:persistgrantsgovxmldb}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Duration"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "invoke_duration"
+              alias              = "Duration"
+            }
+            query {
+              metric_query {
+                name  = "invoke_duration"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:persistgrantsgovxmldb}"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_timeout"
+              alias              = "Timeout"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_timeout"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:persistgrantsgovxmldb}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      // Shows counts of opportunities saved vs failed
+      widget {
+        timeseries_definition {
+          title          = "Opportunity Records Saved vs Failed"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "records_saved"
+              alias              = "Saved"
+              style {
+                palette       = "cool"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_saved"
+                query = "sum:grants_ingest.PersistGrantsGovXMLDB.opportunity.saved{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "records_failed"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_failed"
+                query = "sum:grants_ingest.PersistGrantsGovXMLDB.opportunity.failed{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 21
+      width  = 12
+      height = 3
+    }
+  }
+
+  // PublishGrantEvents
+  widget {
+    group_definition {
+      title       = "PublishGrantEvents"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Status"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "invoke_success"
+              alias              = "Succeeded"
+            }
+            query {
+              metric_query {
+                name  = "invoke_success"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:publishgrantevents}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_failure"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:publishgrantevents}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Duration"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "invoke_duration"
+              alias              = "Duration"
+            }
+            query {
+              metric_query {
+                name  = "invoke_duration"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:publishgrantevents}"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_timeout"
+              alias              = "Timeout"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_timeout"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:publishgrantevents}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      // Shows counts of events published successfully vs failed to publish
+      widget {
+        timeseries_definition {
+          title          = "Events Published vs Failed"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "event_published"
+              alias              = "Published"
+              style {
+                palette       = "cool"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "event_published"
+                query = "sum:grants_ingest.PublishGrantEvents.event.published{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "records_failed"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_failed"
+                query = "sum:grants_ingest.PublishGrantEvents.event.published{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      // Shows invocation batch sizes from DynamoDB
+      widget {
+        timeseries_definition {
+          title          = "Invocation Batch Size"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "batch_size"
+              alias              = "Records"
+              style {
+                palette       = "cool"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "batch_size"
+                query = "sum:grants_ingest.PublishGrantEvents.invocation_batch_size{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 3
+          width  = 4
+          height = 3
+        }
+      }
+
+      // Shows DLQ size
+      widget {
+        timeseries_definition {
+          title          = "DLQ Size"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "queue_size"
+              alias              = "Records"
+              style {
+                palette       = "warm"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "queue_size"
+                query = "sum:aws.sqs.approximate_number_of_messages_visible{$env,$service,$version,queuename:publish_grant_events_dlq}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 3
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 24
+      width  = 12
+      height = 6
+    }
+  }
+
+  // Publishing Operations (from PublishGrantEvents)
+  widget {
+    group_definition {
+      title       = "Publishing Operations"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        note_definition {
+          content          = trimspace(file("${local.datadog_notes_dir}/publishing_operations.md"))
+          background_color = "white"
+          font_size        = "14"
+          has_padding      = true
+          text_align       = "left"
+          vertical_align   = "top"
+          show_tick        = false
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 13
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Malformatted Fields"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "occurrences"
+            }
+            query {
+              metric_query {
+                name  = "occurrences"
+                query = "sum:grants_ingest.PublishGrantEvents.item_image.malformatted_field{$env,$service,$version} by {field}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Build Attempts: New vs Old Images"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "attempts"
+            }
+            query {
+              metric_query {
+                name  = "attempts"
+                query = "sum:grants_ingest.PublishGrantEvents.item_image.build{$env,$service,$version} by {change}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Build Attempts: OldImage: Errors"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            style {
+              palette = "warm"
+            }
+
+            formula {
+              alias              = "Images with Invalid Grant Data"
+              formula_expression = "invalid"
+            }
+            query {
+              metric_query {
+                name  = "invalid"
+                query = "sum:grants_ingest.PublishGrantEvents.grant_data.invalid{$env,$service,$version,change:oldimage}.as_count()"
+              }
+            }
+
+            formula {
+              alias              = "Unbuildable Images"
+              formula_expression = "unbuildable"
+            }
+            query {
+              metric_query {
+                name  = "unbuildable"
+                query = "sum:grants_ingest.PublishGrantEvents.item_image.unbuildable{$env,$service,$version,change:oldimage}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 3
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Build Attempts: NewImage: Errors"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            style {
+              palette = "warm"
+            }
+
+            formula {
+              alias              = "Images with Invalid Grant Data"
+              formula_expression = "invalid"
+            }
+            query {
+              metric_query {
+                name  = "invalid"
+                query = "sum:grants_ingest.PublishGrantEvents.grant_data.invalid{$env,$service,$version,change:newimage}.as_count()"
+              }
+            }
+
+            formula {
+              alias              = "Unbuildable Images"
+              formula_expression = "unbuildable"
+            }
+            query {
+              metric_query {
+                name  = "unbuildable"
+                query = "sum:grants_ingest.PublishGrantEvents.item_image.unbuildable{$env,$service,$version,change:newimage}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 3
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Events Published"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "published"
+            }
+            query {
+              metric_query {
+                name  = "published"
+                query = "sum:grants_ingest.PublishGrantEvents.event.published{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 6
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Unpublishable Events"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+            style {
+              palette = "warm"
+            }
+
+            formula {
+              formula_expression = "failures"
+            }
+            query {
+              metric_query {
+                name  = "failures"
+                query = "sum:grants_ingest.PublishGrantEvents.record.failed{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 6
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Stream Item Processing Results"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+          yaxis {
+            label = "Items"
+            scale = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "failed"
+              alias              = "Failed"
+              style {
+                palette = "warm"
+              }
+            }
+            query {
+              metric_query {
+                name  = "failed"
+                query = "sum:grants_ingest.PublishGrantEvents.record.failed{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "published"
+              alias              = "Published"
+              style {
+                palette = "cool"
+              }
+            }
+            query {
+              metric_query {
+                name  = "published"
+                query = "sum:grants_ingest.PublishGrantEvents.event.published{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "total_in_invocation - published - failed"
+              alias              = "Unprocessed"
+              style {
+                palette       = "gray"
+                palette_index = 6
+              }
+            }
+            query {
+              metric_query {
+                name  = "total_in_invocation"
+                query = "sum:grants_ingest.PublishGrantEvents.invocation_batch_size{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 9
+          width  = 8
+          height = 4
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 30
+      width  = 12
+      height = 13
+    }
+  }
+
+  // ReceiveFFISEmail
+  widget {
+    group_definition {
+      title       = "ReceiveFFISEmail"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Status"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "invoke_success"
+              alias              = "Succeeded"
+            }
+            query {
+              metric_query {
+                name  = "invoke_success"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:receiveffisemail}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_failure"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:receiveffisemail}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Duration"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "invoke_duration"
+              alias              = "Duration"
+            }
+            query {
+              metric_query {
+                name  = "invoke_duration"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:receiveffisemail}"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_timeout"
+              alias              = "Timeout"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_timeout"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:receiveffisemail}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Untrusted Emails"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+            style {
+              palette = "warm"
+            }
+
+            formula {
+              formula_expression = "untrusted"
+            }
+            query {
+              metric_query {
+                name  = "untrusted"
+                query = "sum:grants_ingest.ReceiveFFISEmail.email.untrusted{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 43
+      width  = 12
+      height = 3
+    }
+  }
+
+  // SplitFFISSpreadsheet
+  widget {
+    group_definition {
+      title       = "SplitFFISSpreadsheet"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Status"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "invoke_success"
+              alias              = "Succeeded"
+            }
+            query {
+              metric_query {
+                name  = "invoke_success"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:splitffisspreadsheet}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_failure"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:splitffisspreadsheet}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Duration"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "invoke_duration"
+              alias              = "Duration"
+            }
+            query {
+              metric_query {
+                name  = "invoke_duration"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:splitffisspreadsheet}"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_timeout"
+              alias              = "Timeout"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_timeout"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:splitffisspreadsheet}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Grant Opportunities Results"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "records_created"
+              alias              = "Created"
+              style {
+                palette       = "classic"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_created"
+                query = "sum:grants_ingest.SplitFFISSpreadsheet.opportunity.created{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "records_failed"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_failed"
+                query = "sum:grants_ingest.SplitFFISSpreadsheet.opportunity.failed{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Spreadsheet Size"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "row_count"
+            }
+            query {
+              metric_query {
+                name  = "row_count"
+                query = "sum:grants_ingest.SplitFFISSpreadsheet.spreadsheet.row_count{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 3
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Cell Parsing Errors"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "errors"
+              style {
+                palette = "warm"
+              }
+            }
+            query {
+              metric_query {
+                name  = "errors"
+                query = "sum:grants_ingest.SplitFFISSpreadsheet.spreadsheet.cell_parsing_errors{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 3
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 46
+      width  = 12
+      height = 6
+    }
+  }
+
+  // SplitGrantsGovXMLDB
+  widget {
+    group_definition {
+      title       = "SplitGrantsGovXMLDB"
+      show_title  = true
+      layout_type = "ordered"
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Status"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "invoke_success"
+              alias              = "Succeeded"
+            }
+            query {
+              metric_query {
+                name  = "invoke_success"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_failure"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_failure"
+                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 0
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Invocation Duration"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          request {
+            display_type = "line"
+
+            formula {
+              formula_expression = "invoke_duration"
+              alias              = "Duration"
+            }
+            query {
+              metric_query {
+                name  = "invoke_duration"
+                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:splitgrantsgovxmldb}"
+              }
+            }
+
+            formula {
+              formula_expression = "invoke_timeout"
+              alias              = "Timeout"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "invoke_timeout"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:splitgrantsgovxmldb}"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 4
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+
+      widget {
+        timeseries_definition {
+          title          = "Grant Opportunities Results"
+          show_legend    = true
+          legend_layout  = "horizontal"
+          legend_columns = ["sum"]
+
+          yaxis {
+            include_zero = false
+            scale        = "sqrt"
+          }
+
+          request {
+            display_type = "bars"
+
+            formula {
+              formula_expression = "records_skipped"
+              alias              = "Skipped"
+              style {
+                palette       = "cool"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_skipped"
+                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.skipped{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "records_updated"
+              alias              = "Updated"
+              style {
+                palette       = "purple"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_updated"
+                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.updated{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "records_created"
+              alias              = "Created"
+              style {
+                palette       = "classic"
+                palette_index = 4
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_created"
+                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.created{$env,$service,$version}.as_count()"
+              }
+            }
+
+            formula {
+              formula_expression = "records_failed"
+              alias              = "Failed"
+              style {
+                palette       = "warm"
+                palette_index = 5
+              }
+            }
+            query {
+              metric_query {
+                name  = "records_failed"
+                query = "sum:grants_ingest.SplitGrantsGovXMLDB.opportunity.failed{$env,$service,$version}.as_count()"
+              }
+            }
+          }
+        }
+        widget_layout {
+          x      = 8
+          y      = 0
+          width  = 4
+          height = 3
+        }
+      }
+    }
+    widget_layout {
+      x      = 0
+      y      = 52
+      width  = 12
+      height = 3
     }
   }
 }

--- a/terraform/datadog_notes/publishing_operations.md
+++ b/terraform/datadog_notes/publishing_operations.md
@@ -1,0 +1,31 @@
+## Event Publishing Results
+
+### Invocation Data
+
+- A batch item is added to the DynamoDB stream after every item create/update/delete operation.
+- Created items have a "new" image that shows the inserted data, but no "old" image.
+- Updated items have both a "new" and "old" image, reflecting the new and previous revision of the modified item, respectively.
+- Deleted items have only an "old" image, reflecting the deleted data, but no "new" image. Note that deletions do not occur in normal ingest pipeline operations.
+
+### Scenarios
+
+- Image build attempts: `PublishGrantEvents` will always attempt to build a publishable event for each new and/or old image associated with each item received from the DynamoDB stream.
+  - Every attempt to builld event data from an image will emit an `item_image.build` metric.
+  - An updated item, which provides both new and old images, will therefore emit either 1 or 2 `item_image.build` metrics within a single invocation. Old images will only be attempted after the associated new image was built successfully.
+  - Created and deleted, which only provide a new **or** old image, will always emit exactly 1 `item_image.build` metric within a single invocation.
+  - A single invocation will make up to 1 attempt to build a publishable event for each item received from the DynamoDB stream. Items which fail to build may be retried across subsequent invocations. The first stream item which fails to yield a published event will cause the invocation to end; any unprocessed stream items will be provided to a separate invocation.
+  - Every invocation will emit up to 1 `record.failed` metric.
+- Unbuildable image: The data in an image (either new or old) could not be used to build a publishable event because at least one of its fields could not be understood by the mapper.
+  - Unbuildable images will always emit an `item_image.unbuildable` metric, tagged with either `change:NewImage` or `change:OldImage`.
+- Malformatted field: A field from an image could not be understood by the mapper.
+  - This is not necessarily fatal, but may be correlated with fatal validation errors.
+  - Malformatted fields will always be represented in WARN-level log output.
+  - Malformatted fields will always emit a `item_image.malformatted_field`.
+- Validation error: An event was built, but was found to be invalid due to missing or unexpected values according to the USDR `GrantModificationEvent` schema.
+  - Events may be published if validation errors only pertain to data in its `previous` property (that is, data from an old image).
+  - Validation errors pertaining to newly-persisted data **will** prevent an event from being published.
+  - Validation errors will always emit a `grant_data.invalid` metric.
+- Event published: Up to 1 event will be published for each item received from the DynamoDB stream.
+  - Each published event will always emit exactly 1 `event.published` metric.
+  - Therefore, each invocation may emit up to N `event.published` metrics, where N is equal to the invocation batch size.
+  - Every invocation emits exactly 1 `invocation_batch_size` metric which represents the number of items received from the DynamoDB stream.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,6 +6,10 @@ output "grants_prepared_data_bucket_id" {
   value = module.grants_prepared_data_bucket.bucket_id
 }
 
+output "service_dashboard_url" {
+  value = var.datadog_dashboards_enabled ? "https://app.datadoghq.com${one(datadog_dashboard.service_dashboard[*].url)}" : null
+}
+
 output "lambda_functions" {
   value = [
     module.DownloadGrantsGovDB.lambda_function_name,

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,9 +1,14 @@
 namespace                             = "grants_ingest"
 environment                           = "production"
 ssm_deployment_parameters_path_prefix = "/grants_ingest/production/deploy-config"
-datadog_enabled                       = true
 lambda_default_log_retention_in_days  = 30
 lambda_default_log_level              = "INFO"
-datadog_draft                         = false
-datadog_monitors_enabled              = true
 ffis_ingest_email_address             = "ffis-ingest@grants.usdigitalresponse.org"
+
+datadog_enabled          = true
+datadog_draft            = false
+datadog_monitors_enabled = true
+datadog_monitor_notification_handles = [
+  "thendrickson@usdigitalresponse.org",
+  "asridhar@usdigitalresponse.org",
+]

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -10,6 +10,13 @@ ffis_ingest_email_address             = "ffis-ingest@staging.grants.usdr.dev"
 
 // Only defined in staging
 datadog_metrics_metadata = {
+  "DownloadFFISSpreadsheet.source_size" = {
+    short_name  = "Source file size in bytes"
+    description = "Size (in bytes) of the downloaded ffis.org spreadsheet file."
+    unit        = "byte"
+    per_unit    = "file"
+  }
+
   "DownloadGrantsGovDB.source_size" = {
     short_name  = "Source file size in bytes"
     description = "Size (in bytes) of the downloaded grants.gov database archive file."
@@ -17,34 +24,40 @@ datadog_metrics_metadata = {
     per_unit    = "file"
   }
 
-  "SplitGrantsGovXMLDB.opportunity.created" = {
-    short_name  = "New grant opportunities"
-    description = "Count of new grant opportunity records created during invocation."
+  "ExtractGrantsGovDBToXML.archive.downloaded" = {
+    short_name  = "Downloaded archive files"
+    description = "Count of downloaded Grants.gov DB zip archives for extraction."
+    unit        = "file"
+  }
+
+  "ExtractGrantsGovDBToXML.xml.extracted" = {
+    short_name  = "Extracted XML files"
+    description = "Count of XML files extracted from the Grants.gov DB zip archive."
+    unit        = "file"
+  }
+
+  "ExtractGrantsGovDBToXML.xml.uploaded" = {
+    short_name  = "Uploaded XML files"
+    description = "Count of uploaded XML files after extraction."
+    unit        = "file"
+  }
+
+  "PersistFFISData.opportunity.saved" = {
+    short_name  = "Saved opportunities"
+    description = "Count of opportunity records persisted to DynamoDB with FFIS.org data."
     unit        = "record"
   }
 
-  "SplitGrantsGovXMLDB.opportunity.updated" = {
-    short_name  = "Updated grant opportunities"
-    description = "Count of modified grant opportunity records updated during invocation."
+  "PersistGrantsGovXMLDB.opportunity.saved" = {
+    short_name  = "Saved opportunities"
+    description = "Count of opportunity records persisted to DynamoDB with Grants.gov data."
     unit        = "record"
   }
 
-  "SplitGrantsGovXMLDB.opportunity.skipped" = {
-    short_name  = "Skipped grant opportunities"
-    description = "Count of unchanged grant opportunity records skipped during invocation."
+  "PersistGrantsGovXMLDB.opportunity.failed" = {
+    short_name  = "Failed opportunities"
+    description = "Count of opportunity records that failed to be persisted to DynamoDB with Grants.gov data."
     unit        = "record"
-  }
-
-  "SplitGrantsGovXMLDB.opportunity.failed" = {
-    short_name  = "Failed grant opportunities"
-    description = "Count of grant opportunity records that failed to process during invocation."
-    unit        = "record"
-  }
-
-  "ReceiveFFISEmail.email.untrusted" = {
-    short_name  = "Received untrusted email"
-    description = "Count of received emails that were determined to be untrustworthy."
-    unit        = "email"
   }
 
   "PublishGrantEvents.invocation_batch_size" = {
@@ -87,5 +100,59 @@ datadog_metrics_metadata = {
     short_name  = "Invalid mapper results"
     description = "Count of grants mapped from a DynamoDB item image that failed target schema validation."
     unit        = "document"
+  }
+
+  "ReceiveFFISEmail.email.untrusted" = {
+    short_name  = "Received untrusted email"
+    description = "Count of received emails that were determined to be untrustworthy."
+    unit        = "email"
+  }
+
+  "SplitFFISSpreadsheet.opportunity.created" = {
+    short_name  = "New grant opportunities"
+    description = "Count of new grant opportunity records created from FFIS.org data during invocation."
+    unit        = "record"
+  }
+
+  "SplitFFISSpreadsheet.opportunity.failed" = {
+    short_name  = "Failed grant opportunities"
+    description = "Count of grant opportunity records from Grants.gov data that failed to process during invocation."
+    unit        = "record"
+  }
+
+  "SplitFFISSpreadsheet.spreadsheet.row_count" = {
+    short_name  = "Spreadsheet row count"
+    description = "Number of rows contained in source spreadsheets from FFIS.org."
+    unit        = "row"
+  }
+
+  "SplitFFISSpreadsheet.cell_parsing_errors" = {
+    short_name  = "Spreadsheet cell parsing errors"
+    description = "Count of parsing errors encountered in source spreadsheets from FFIS.org."
+    unit        = "error"
+  }
+
+  "SplitGrantsGovXMLDB.opportunity.created" = {
+    short_name  = "New grant opportunities"
+    description = "Count of new grant opportunity records created from Grants.gov data during invocation."
+    unit        = "record"
+  }
+
+  "SplitGrantsGovXMLDB.opportunity.updated" = {
+    short_name  = "Updated grant opportunities"
+    description = "Count of modified grant opportunity records updated from Grants.gov data during invocation."
+    unit        = "record"
+  }
+
+  "SplitGrantsGovXMLDB.opportunity.skipped" = {
+    short_name  = "Skipped grant opportunities"
+    description = "Count of unchanged grant opportunity records from Grants.gov data skipped during invocation."
+    unit        = "record"
+  }
+
+  "SplitGrantsGovXMLDB.opportunity.failed" = {
+    short_name  = "Failed grant opportunities"
+    description = "Count of grant opportunity records from Grants.gov data that failed to process during invocation."
+    unit        = "record"
   }
 }


### PR DESCRIPTION
### Closes #301 

## Description

This PR updates the Datadog service dashboard to provide a full overview of service health and general operational status. It also includes a few related modifications outside the direct scope of #301:
- Updates `DownloadFFISSpreadsheet` to emit a file size metric (a la `DownloadGrantsGovDB`)
- Registers notification handles for monitoring alerts (we'll probably want to update these to a monitoring integration and/or Slack, but I think the initial values are fine to start).
- Updates custom metric definitions to be comprehensive of all custom metrics emitted by the service
- Tags `cell_parsing_errors` metrics emitted by `SplitFFISSpreadsheet` with a `target` value that refers to the field targeted by the parsing operation

## Testing

Check out the dashboard provisioned under a sandbox deployment [here](https://app.datadoghq.com/dashboard/xc4-j5x-p4q/grants-ingest-service-dashboard-draft---sandbox). The contents are pretty much identical to what will be included in the final release; and you can adjust the dashboard `env` variable in the browser to view non-sandbox environments.



### Preview (`env:staging` is selected in the screenshot):
![image](https://github.com/usdigitalresponse/grants-ingest/assets/1851017/63fdc037-9ec7-4a6c-b44a-c9962d4c921f)


### Automated and Unit Tests
- [ ] Added Unit tests

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
