### PR TITLE
Fix: Generate fresh `revision` values when persisting FFIS data

### DIFF
--- a/cmd/PersistFFISData/dynamodb.go
+++ b/cmd/PersistFFISData/dynamodb.go
@@ -32,6 +32,7 @@ func UpdateOpportunity(ctx context.Context, c DynamoDBUpdateItemAPI, table strin
 	condition, _ := awsHelpers.DDBIfAnyValueChangedCondition(oppAttr)
 
 	update := expression.Set(expression.Name("Bill"), expression.Value(oppAttr["Bill"]))
+	update = awsHelpers.DDBSetRevisionForUpdate(update)
 
 	expr, err := expression.NewBuilder().WithUpdate(update).WithCondition(condition).Build()
 	if err != nil {

--- a/cmd/PersistFFISData/dynamodb_test.go
+++ b/cmd/PersistFFISData/dynamodb_test.go
@@ -55,11 +55,23 @@ func TestUpsertDynamoDB(t *testing.T) {
 			}
 			values := make(map[string]string)
 			attributevalue.UnmarshalMap(passedParams.ExpressionAttributeValues, &values)
-			if values[":0"] != test.bill {
-				t.Errorf("Expected bill %v, got %v", test.bill, values[":0"])
+			if !checkMapContainsValue(t, values, test.bill) {
+				t.Error("Missing bill value in update attribute values")
 			}
-
+			if !checkMapContainsValue(t, passedParams.ExpressionAttributeNames, "revision") {
+				t.Errorf("Missing attribute %q in update attribute names", "revision")
+			}
 		})
 	}
+}
 
+// checkMapContainsValue is a testing helper function that returns true if target is a value of m
+func checkMapContainsValue[K comparable, V comparable](t *testing.T, m map[K]V, target V) bool {
+	t.Helper()
+	for _, v := range m {
+		if v == target {
+			return true
+		}
+	}
+	return false
 }

--- a/terraform/datadog_dashboard.tf
+++ b/terraform/datadog_dashboard.tf
@@ -1148,7 +1148,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "records_failed"
-                query = "sum:grants_ingest.PublishGrantEvents.event.published{$env,$service,$version}.as_count()"
+                query = "sum:grants_ingest.PublishGrantEvents.event.failed{$env,$service,$version}.as_count()"
               }
             }
           }


### PR DESCRIPTION
### Fixes #304 

## Description

This PR provides a fix for the bug described in #304. The solution involves updating the `PersistFFISData` Lambda function to generate new `revision` values as a conditional update value in the same manner as already implemented in `PersistGrantsGovXMLDB`.

This PR includes an additional fix for an incorrect dashboard metric that I noticed while debugging this issue.

## Testing

1. Invoke `PersistFFISData` with an S3 object containing FFIS data that is not currently present in the configured DynamoDB table.
  - Verify that after the invocation completes, a new item exists in the table that has `OpportunityID` and `Bill` values that match the values provided by the source S3 object.
  - Verify that the new item also contains a non-null `revision` value.
  - Note the `revision` value.
2. Modify the S3 object used in Step 1 by changing its funding bill value.
3. Invoke `PersistFFISData` (this may happen automatically upon modifying the S3 object if bucket events are enabled in the test environment).
  - Verify that after invocation completes, the table item's `Bill` value reflects the new value provided by the source S3 object.
  - Verify that the updated item's `revision` value is different than the value noted in Step 1.
  - Optionally, verify that the updated item's `revision` value compares as greater than the value noted in Step 1.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
