### PR TITLE
Maintenance: Migrate staging namespace

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,8 @@ categories:
 category-template: '### $TITLE'
 exclude-labels:
   - skip-changelog
+exclude-contributors:
+  - dependabot
 autolabeler:
   - label: go
     files:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -334,7 +334,9 @@ data "aws_iam_policy_document" "ses_source_data_s3_access" {
       "s3:PutObject",
     ]
 
-    resources = ["${module.email_delivery_bucket.bucket_arn}/ses/*"]
+    resources = [
+      "arn:aws:s3:::${var.namespace}-emaildelivery-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}/ses/*",
+    ]
 
     condition {
       test     = "StringEquals"

--- a/terraform/staging.s3.tfbackend
+++ b/terraform/staging.s3.tfbackend
@@ -1,5 +1,5 @@
 region         = "us-west-2"
 bucket         = "357150818708-us-west-2-terraform"
 key            = "usdr/grants_ingest/staging/us-west-2/terraform.tfstate"
-dynamodb_table = "grantsingest-staging-terraform-lock"
+dynamodb_table = "grantsingest-terraform-lock"
 encrypt        = "true"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -1,6 +1,6 @@
-namespace                             = "grants_ingest-staging"
+namespace                             = "grants_ingest"
 environment                           = "staging"
-ssm_deployment_parameters_path_prefix = "/grants_ingest/staging/deploy-config"
+ssm_deployment_parameters_path_prefix = "/grants_ingest/deploy-config"
 datadog_enabled                       = true
 lambda_default_log_retention_in_days  = 30
 lambda_default_log_level              = "INFO"


### PR DESCRIPTION
## Description

This PR migrates (recreates) the grants-ingest service in our staging environment upon merge to `main`.

There are ~two~ (edit: three) changes to this PR:
1. As part of the redeployment operation, we're removing the `staging` prefix from the namespace label used on resources. This isn't really useful for disambiguating anything, since AWS environments are fully isolated, and requires some odd workarounds to make cross-environment resources (like those in Datadog) target resources consistently across multiple environments (e.g. the Lambda `functionname` tag is inconsistent across environments when it's prefixed with the environment name).
2. Prevent dependabot from being cluttering up the release notes' contributors list.
3. Update the way we self-reference the email delivery bucket in its bucket policy document. Since the bucket and its policy are somewhat codependent, Terraform has issues resolving resource counts when the policy module references the bucket module. The solution is to simply set the name of the bucket directly in the policy rather than using a Terraform reference.

## Checklist
- [x] Provided ticket and description
- [x] Added PR reviewers
