### PR TITLE
Add missing `pull-requests: write` permissions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -68,6 +68,7 @@ jobs:
     name: Publish Terraform Plan
     permissions:
       contents: read
+      pull-requests: write
     if: needs.tf-plan.result != 'skipped' || needs.tf-plan.result != 'cancelled'
     needs:
       - tf-plan

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -68,6 +68,7 @@ jobs:
     name: Publish Terraform Plan
     permissions:
       contents: read
+      pull-requests: write
     if: needs.tf-plan.result != 'skipped' || needs.tf-plan.result != 'cancelled'
     needs:
       - tf-plan


### PR DESCRIPTION
### Related to #335

## Description

Fixes missing permissions required for workflows that call the "Publish Terraform Plan" reusable workflow. 

Problem: Even though "Deploy Staging" and "Deploy Production" workflows don't need to comment on PRs, they use the "Publish Terraform Plan" workflow, which potentially does. Since GHA doesn't allow conditional permissions on reusable workflows, the callers need to grant the full scope of potentially-required permissions. This should be okay from a security perspective, since commenting on a PR in this context is not considered particularly sensitive, and any changes to the callers will need to be reviewed first.
