### PR TITLE
Fix error when removing nonexistent artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Prepare artifacts output directory
         run: |
           mkdir -p $(dirname $ARTIFACTS_PATH)
-          rm "$ARTIFACTS_PATH"
+          rm -f "$ARTIFACTS_PATH"
       - name: Build CLI
         id: build
         run: task build-cli

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -14,7 +14,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
-    # if: github.event_name ==
+    if: github.event_name == 'pull_request'
     steps:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
@@ -27,9 +27,6 @@ jobs:
         with:
           show-progress: 'false'
           persist-credentials: 'false'
-      - run: echo "$DEBUG_EVENT_NAME"
-        env:
-          DEBUG_EVENT_NAME: ${{ github.event_name }}
       - uses: actions/dependency-review-action@v3
 
   codeql:

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -14,6 +14,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    # if: github.event_name ==
     steps:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
@@ -26,6 +27,9 @@ jobs:
         with:
           show-progress: 'false'
           persist-credentials: 'false'
+      - run: echo "$DEBUG_EVENT_NAME"
+        env:
+          DEBUG_EVENT_NAME: ${{ github.event_name }}
       - uses: actions/dependency-review-action@v3
 
   codeql:


### PR DESCRIPTION
### Relates to #335 

## Description

This PR avoids an error condition that surfaces when preparing the `bin/` directory during the "Build CLI" step of the reusable "Build" workflow.

Problem: The step `rm`s any preexisting `bin/grants-ingest` artifact as a precautionary step before building. In normal cases, no preexisting artifact should exist, so `rm bin/grants-ingest` fails with a "No such file or directory" error. 

Solution: Use `rm -f` to silence errors when the file does not exist.

**Update:** This PR also fixes an issue where the "Dependency Review" job was executing for non-PR workflows.

Problem: The "Dependency Review" job is part of the "Code Scanning" workflow, which runs on multiple events. However, dependency reviews are only useful when changes can be compared (i.e. during PRs). Because the workflow was missing a base and head ref for comparison, it threw an error.

Solution: Only run "Dependency Review" in PRs by making it conditional on `github.event_type == 'pull_request'`.