### PR TITLE
Fix: typo in command when uploading TF plan

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -196,7 +196,7 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.gpg-passphrase }}
         run: |
-          gpg --batch --yes --passphrase "$GPG_PASSPHRASE" 0 -c --cipher-algo AES256 tfplan
+          gpg --batch --yes --passphrase "$GPG_PASSPHRASE" -c --cipher-algo AES256 tfplan
           rm tfplan
       - name: Store terraform artifacts
         if: success() && inputs.upload-artifacts


### PR DESCRIPTION
### Relates to #335 

## Description

This PR fixes a typo introduced in #335 that manifests when encrypting Terraform plan file artifacts before upload. 

Problem: An extra character was being passed as an option to `gpg`.
Solution: Remove the character.

**Note:** Will merge without waiting for checks to pass, as the problematic step does not execute during PR events (which is why we missed this in the first place – TF plan artifacts are only needed for deployments).