### PR TITLE
Fix: Bugs during post-plan deployment steps

### DIFF
--- a/.github/workflows/publish-terraform-plan.yml
+++ b/.github/workflows/publish-terraform-plan.yml
@@ -128,7 +128,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: Terraform Summary
       - name: Create or update comment
-        if: always()
+        if: inputs.write-comment && inputs.pr-number != ''
         uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -77,6 +77,8 @@ jobs:
         with:
           name: ${{ inputs.tf-plan-artifacts-key }}
           path: ${{ github.workspace }}/terraform
+      - name: Clear any cached provider plugins in artifact
+        run: rm -rf "$TF_PLUGIN_CACHE_DIR"
       - name: Get project TF version
         id: get_tf_version
         run: echo "TF_VERSION=$(cat .terraform-version | tr -d '[:space:]')" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -205,6 +205,7 @@ jobs:
           name: ${{ env.ARTIFACTS_KEY }}
           path: |
             ${{ github.workspace }}/terraform
+            !${{ env.TF_PLUGIN_CACHE_DIR }}
             !${{ github.workspace }}/terraform/.terraform
           if-no-files-found: error
           retention-days: ${{ inputs.artifacts-retention-days }}


### PR DESCRIPTION
### Relates to #335 

## Description

This PR fixes two bugs introduced in #335 that show up in deployment workflows after a Terraform plan has been generated:
- Problem: When publishing a summary for the plan, the workflow attempts to create or update a PR comment. However, we're not working against a PR during deployment, so no PR number exists. Other related workflow steps are skipped when no PR number is provided, but I neglected to do so for this step.
  - Solution: Add the same `if: inputs.write-comment && inputs.pr-number != ''` conditional check to the "Create or update comment" step of the "Publish Terraform Plan" workflow.
- Problem: The terraform provider plugin directory is currently added to the Terraform plan artifact. This [causes issues](https://stackoverflow.com/questions/70407525/terraform-gives-errors-failed-to-load-plugin-schemas) when running `terraform init` before applying the generated plan, due to how GitHub stores (and restores) artifacts, which makes Terraform see them as corrupt.
  - Solution:
    - Exclude the directory when creating the artifact.
    - Also, remove any such directory after restoring the artifact (just in case).
