### PR TITLE
Set TF lock table name for Prod

### DIFF
--- a/terraform/production.s3.tfbackend
+++ b/terraform/production.s3.tfbackend
@@ -1,5 +1,5 @@
 region         = "us-west-2"
 bucket         = "729134339726-us-west-2-terraform"
 key            = "usdr/grants_ingest/prod/us-west-2/terraform.tfstate"
-dynamodb_table = "grantsingest-prod-terraform-lock"
+dynamodb_table = "grantsingest-terraform-lock"
 encrypt        = "true"


### PR DESCRIPTION
## Description

This PR sets the DynamoDB table name used by Terraform to lock the Production environment during plan/apply operations. It enables initial release of the grants-ingest service 🎉 