### PR TITLE
Parallelize QA jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,10 @@ updates:
     directory: /
     schedule:
       interval: daily
-  - package-ecosystem: "terraform"
-    directory: "/terraform"
+  - package-ecosystem: terraform
+    directory: /terraform
     schedule:
-      interval: "daily"
+      interval: daily
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     directory: "/terraform"
     schedule:
       interval: "daily"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,7 +280,7 @@ jobs:
         run: |
           REPORT_FILE=$(mktemp -t summary.md.XXXXX)
           cat >> $REPORT_FILE << 'ENDOFREPORT'
-          ## Build Lambdas Summary
+          ## Build CLI Summary
 
           <details>
           <summary>Compiled Checksums (before packing)</summary>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: Continuous Integration
 
 on:
-  pull_request_target: {}
+  # pull_request_target: {}
+  pull_request: {}
 
 jobs:
   qa:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: Continuous Integration
 
 on:
-  # pull_request_target: {}
-  pull_request: {}
+  pull_request_target: {}
 
 jobs:
   qa:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -109,6 +109,8 @@ jobs:
   update_release:
     name: Update release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
       - tf-apply
     env:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -18,7 +18,13 @@ jobs:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
@@ -55,7 +61,13 @@ jobs:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
@@ -90,7 +102,11 @@ jobs:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
@@ -112,7 +128,11 @@ jobs:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
@@ -136,7 +156,13 @@ jobs:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -11,22 +11,14 @@ permissions:
   contents: read
 
 jobs:
-  qa_go:
-    name: QA for Go
+  prepare-go-qa:
+    name: Prepare for Go QA
     runs-on: ubuntu-latest
     steps:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            proxy.golang.org:443
-            sum.golang.org:443
-            storage.googleapis.com:443
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
@@ -53,15 +45,121 @@ jobs:
         run: task prebuild-lambda
       - name: Check Formatting
         run: test -z "$(go fmt ./...)" || echo "Formatting check failed."
-      - name: Test
+
+  go-test:
+    name: Run Go Tests
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-go-qa
+    steps:
+      - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          show-progress: 'false'
+          persist-credentials: 'false'
+      - name: Restore Taskfile cache
+        uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-qa-taskfile
+          path: |
+            ./.task
+            ./bin
+            ./cover.out
+            ./cover.html
+      - uses: actions/setup-go@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          go-version-file: go.mod
+      - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+      - name: Run tests
         run: task test
-      - name: Vet
+
+  go-vet:
+    name: Vet Go Code
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-go-qa
+    steps:
+      - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          show-progress: 'false'
+          persist-credentials: 'false'
+      - uses: actions/setup-go@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          go-version-file: go.mod
+      - name: Vet source code
         run: go vet ./...
-      - name: Lint
+
+  go-lint:
+    name: Lint Go Code
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-go-qa
+    steps:
+      - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          show-progress: 'false'
+          persist-credentials: 'false'
+      - uses: actions/setup-go@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          go-version-file: go.mod
+      - name: Lint with Staticcheck
         uses: dominikh/staticcheck-action@v1.3.0
         with:
           install-go: false
-      - name: Ensure all go binaries compile
+
+  go-build:
+    name: Ensure Go Builds
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-go-qa
+    steps:
+      - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          show-progress: 'false'
+          persist-credentials: 'false'
+      - name: Restore Taskfile cache
+        uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-qa-taskfile
+          path: |
+            ./.task
+            ./bin
+            ./cover.out
+            ./cover.html
+      - uses: actions/setup-go@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          go-version-file: go.mod
+      - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+      - name: Ensure all binaries can compile
         run: task build build-cli
 
   tflint:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -205,7 +205,7 @@ jobs:
           name: ${{ env.ARTIFACTS_KEY }}
           path: |
             ${{ github.workspace }}/terraform
-            !${{ env.TF_PLUGIN_CACHE_DIR }}
+            !**/${{ env.TF_PLUGIN_CACHE_DIR }}/**
             !${{ github.workspace }}/terraform/.terraform
           if-no-files-found: error
           retention-days: ${{ inputs.artifacts-retention-days }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -94,7 +94,6 @@ jobs:
       TF_CLI_ARGS: "-no-color"
       TF_IN_AUTOMATION: "true"
       TF_INPUT: 0
-      TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
     concurrency:
       group: ${{ inputs.concurrency-group }}
       cancel-in-progress: false
@@ -192,20 +191,17 @@ jobs:
         run: terraform show tfplan
       - name: Encrypt terraform plan file
         id: encrypt_plan
-        if: success() && inputs.upload-artifacts
         env:
           GPG_PASSPHRASE: ${{ secrets.gpg-passphrase }}
         run: |
           gpg --batch --yes --passphrase "$GPG_PASSPHRASE" -c --cipher-algo AES256 tfplan
           rm tfplan
       - name: Store terraform artifacts
-        if: success() && inputs.upload-artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACTS_KEY }}
           path: |
             ${{ github.workspace }}/terraform
-            !**/${{ env.TF_PLUGIN_CACHE_DIR }}/**
             !${{ github.workspace }}/terraform/.terraform
           if-no-files-found: error
           retention-days: ${{ inputs.artifacts-retention-days }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -191,12 +191,14 @@ jobs:
         run: terraform show tfplan
       - name: Encrypt terraform plan file
         id: encrypt_plan
+        if: success() && inputs.upload-artifacts
         env:
           GPG_PASSPHRASE: ${{ secrets.gpg-passphrase }}
         run: |
           gpg --batch --yes --passphrase "$GPG_PASSPHRASE" -c --cipher-algo AES256 tfplan
           rm tfplan
       - name: Store terraform artifacts
+        if: success() && inputs.upload-artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACTS_KEY }}


### PR DESCRIPTION
## Description

Previously, the "QA for Go" job (part of the reusable "QA" workflow) consisted of several steps that were executed sequentially. This PR breaks up the "QA for Go" job  into several smaller jobs that can be more easily parallelized, with a single "Prepare for Go QA" job dependency (which exists as an up-front job that optimizes subsequent ones). 

The net effect should be an overall speedup that means contributors don't need to wait as long for automated QA feedback.

Additionally, this PR adds the `github-actions` ecosystem to the Dependabot configuration for this repo, which will help keep dependencies for CI/CD automations up-to-date.