### PR TITLE
Remove env segment from SSM path prefix in Production

### DIFF
--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,6 +1,6 @@
 namespace                             = "grants_ingest"
 environment                           = "production"
-ssm_deployment_parameters_path_prefix = "/grants_ingest/production/deploy-config"
+ssm_deployment_parameters_path_prefix = "/grants_ingest/deploy-config"
 lambda_binaries_autobuild             = false
 lambda_default_log_retention_in_days  = 30
 lambda_default_log_level              = "INFO"


### PR DESCRIPTION
## Description

This PR removes the `/production/` path segment from SSM deployment parameters, which is a convention we moved away from since the last time this was configured in `production.tfvars`. The prefix now conforms to the actual paths used in this environment.

NB: Searched the codebase for other occurrences of `prod` and `production` and didn't find anything that should impact release.