### PR TITLE
Revert "Build(deps): Bump cloudposse/iam-policy/aws in /terraform (#316)"

### DIFF
--- a/terraform/modules/DownloadFFISSpreadsheet/main.tf
+++ b/terraform/modules/DownloadFFISSpreadsheet/main.tf
@@ -29,7 +29,7 @@ data "aws_sqs_queue" "ffis_downloads" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/DownloadGrantsGovDB/main.tf
+++ b/terraform/modules/DownloadGrantsGovDB/main.tf
@@ -36,7 +36,7 @@ data "aws_s3_bucket" "grants_source_data" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/EnqueueFFISDownload/main.tf
+++ b/terraform/modules/EnqueueFFISDownload/main.tf
@@ -29,7 +29,7 @@ data "aws_sqs_queue" "ffis_downloads" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/ExtractGrantsGovDBToXML/main.tf
+++ b/terraform/modules/ExtractGrantsGovDBToXML/main.tf
@@ -26,7 +26,7 @@ data "aws_s3_bucket" "source_data" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/PersistFFISData/main.tf
+++ b/terraform/modules/PersistFFISData/main.tf
@@ -25,7 +25,7 @@ data "aws_s3_bucket" "prepared_data" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/PersistGrantsGovXMLDB/main.tf
+++ b/terraform/modules/PersistGrantsGovXMLDB/main.tf
@@ -25,7 +25,7 @@ data "aws_s3_bucket" "prepared_data" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/ReceiveFFISEmail/main.tf
+++ b/terraform/modules/ReceiveFFISEmail/main.tf
@@ -33,7 +33,7 @@ data "aws_s3_bucket" "grants_source_data" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/SplitFFISSpreadsheet/main.tf
+++ b/terraform/modules/SplitFFISSpreadsheet/main.tf
@@ -29,7 +29,7 @@ data "aws_s3_bucket" "prepared_data" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {

--- a/terraform/modules/SplitGrantsGovXMLDB/main.tf
+++ b/terraform/modules/SplitGrantsGovXMLDB/main.tf
@@ -29,7 +29,7 @@ data "aws_s3_bucket" "prepared_data" {
 
 module "lambda_execution_policy" {
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.0"
+  version = "1.0.1"
 
   iam_source_policy_documents = var.additional_lambda_execution_policy_documents
   iam_policy_statements = {


### PR DESCRIPTION
### Relates to #316 

## Description

This reverts commit 7e2e3fc51b50841c31645f91ad7ecb271e58870f. 

Since the #316 was from Dependabot, no updates to the usages of the upgrade module were made, which seems to cause issues in Terraform when planning against new environments. We should revisit this upgrade to change the input variables on the various `lambda_execution_policy` modules in a way that is more compatible. However, these changes shouldn't prevent launch.
