### PR TITLE
Exclude dependabot[bot] from special thanks in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,6 +31,7 @@ exclude-labels:
   - skip-changelog
 exclude-contributors:
   - dependabot
+  - 'dependabot[bot]'
 autolabeler:
   - label: go
     files:


### PR DESCRIPTION
## Description

This PR updates the automatic release notes configuration with a new exclusion rule. We currently have an exclusion rule of `dependabot`, but that doesn't seem to be working. My guess is this is due to dependabot showing up as `dependabot[bot]`, which is the new exclusion value.

This is done because we don't need to be thanking our robot overlords (yet) 🤖 
