### PR TITLE
Standardize SQS name prefixes

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -320,6 +320,10 @@ resource "aws_sqs_queue" "ffis_downloads" {
   message_retention_seconds  = 5 * 60 * 60 * 24 # 5 days
   max_message_size           = 1024             # 1 KB
   sqs_managed_sse_enabled    = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 data "aws_iam_policy_document" "ses_source_data_s3_access" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -312,7 +312,7 @@ resource "aws_ses_receipt_rule" "ffis_ingest" {
 }
 
 resource "aws_sqs_queue" "ffis_downloads" {
-  name = "ffis_downloads"
+  name = "${var.namespace}-ffis_downloads"
 
   delay_seconds              = 0
   visibility_timeout_seconds = 15 * 60

--- a/terraform/modules/PublishGrantEvents/main.tf
+++ b/terraform/modules/PublishGrantEvents/main.tf
@@ -32,6 +32,10 @@ resource "aws_sqs_queue" "dlq" {
   message_retention_seconds  = 1209600 // 14 days
   max_message_size           = 262144  // 256 kB
   sqs_managed_sse_enabled    = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 data "aws_dynamodb_table" "source" {

--- a/terraform/modules/PublishGrantEvents/main.tf
+++ b/terraform/modules/PublishGrantEvents/main.tf
@@ -24,7 +24,7 @@ data "aws_cloudwatch_event_bus" "target" {
 }
 
 resource "aws_sqs_queue" "dlq" {
-  name = "publish_grant_events_dlq"
+  name = "${var.namespace}-${var.function_name}-dlq"
 
   visibility_timeout_seconds = 3600 // 1 hour
   delay_seconds              = 0


### PR DESCRIPTION
## Description

This PR addresses some issues related to resource naming conventions in AWS. Currently, although properly-tagged, SQS queue names are lacking a service-standard namespace prefix (which in our case is just the service name in Staging and Production environments). Having consistent resource-naming conventions makes things easier to find, debug, and govern, which is the impetus for this update.

Note: Renaming an SQS queue is a destructive action that requires the queue to be replaced. Therefore, it is generally important to deploy these changes between ingestion batches to avoid data loss. For these changes, we can mitigate risk in a few ways:
1. Production currently has no messages in the DLQ. As long as this change rolls out before another batch update (or between any batches where the DLQ remains empty), the DLQ can be safely destroyed.
2. FFIS emails are not yet being delivered to Production, so data loss for that queue is a non-issue for that environment.
3. Removing the resources from Terraform state prior to deployment will cause Terraform to create the new queues but skip deleting the old ones, which can then be cleaned up manually.

To avoid adding time-sensitive complexities to these changes, I think we should go with Option 3. This will be handled separately, following PR approval.

For good measure, this PR adds the `prevent_destroy = true` [lifecycle meta-argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#prevent_destroy) to both `aws_sqs_queue` resources, which will ensure that Terraform fails on any plan that includes their destruction.

## Checklist
- [x] Provided ticket and description
- [ ] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
