### PR TITLE
Pin all third-party GitHub actions to SHA version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
-      - uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@e26d8975574116b0097a1161e0fe16ba75d84c1c # v1.0.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -122,7 +122,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
-      - uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@e26d8975574116b0097a1161e0fe16ba75d84c1c # v1.0.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -239,7 +239,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
-      - uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@e26d8975574116b0097a1161e0fe16ba75d84c1c # v1.0.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           show-progress: 'false'
           persist-credentials: 'false'
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
@@ -118,7 +118,7 @@ jobs:
         with:
           name: ${{ needs.prepare.outputs.sources-key }}
           path: .
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
@@ -235,7 +235,7 @@ jobs:
         with:
           name: ${{ needs.prepare.outputs.sources-key }}
           path: .
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
             sum.golang.org:443
             raw.githubusercontent.com:443
       - name: Restore Go build sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.prepare.outputs.sources-key }}
           path: .
@@ -231,7 +231,7 @@ jobs:
             sum.golang.org:443
             raw.githubusercontent.com:443
       - name: Restore Go build sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.prepare.outputs.sources-key }}
           path: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         run: task prebuild-lambda
       - name: Store build sources
         id: store
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ env.SOURCES_KEY }}
           path: ${{ env.SOURCES_PATH }}
@@ -197,7 +197,7 @@ jobs:
           UPX_RESULT: ${{ steps.pack.outputs.result }}
       - name: Store build artifacts
         id: store
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ env.ARTIFACTS_KEY }}
           path: ${{ env.ARTIFACTS_PATH }}
@@ -314,7 +314,7 @@ jobs:
           UPX_RESULT: ${{ steps.pack.outputs.result }}
       - name: Store build artifacts
         id: store
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ env.ARTIFACTS_KEY }}
           path: ${{ env.ARTIFACTS_PATH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
             proxy.golang.org:443
             sum.golang.org:443
             storage.googleapis.com:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           show-progress: 'false'
           persist-credentials: 'false'

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -78,5 +78,3 @@ jobs:
       - name: Ensure GitHub action versions are pinned to SHAs
         # uses: zgosalvez/github-actions-ensure-sha-pinned-actions@f32435541e24cd6a4700a7f52bb2ec59e80603b1 # v2.1.4
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@v2.1.4 # Test - should fail
-        with:
-          dry_run: true

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -46,13 +46,13 @@ jobs:
           show-progress: 'false'
           persist-credentials: 'false'
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@8e0b1c74b1d5a0077b04d064c76ee714d3da7637 # v2.14.6
         with:
           languages: go
           queries: security-extended,security-and-quality
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@8e0b1c74b1d5a0077b04d064c76ee714d3da7637 # v2.14.6
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@8e0b1c74b1d5a0077b04d064c76ee714d3da7637 # v2.14.6
         with:
           category: "/language:go"

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -56,3 +56,27 @@ jobs:
         uses: github/codeql-action/analyze@8e0b1c74b1d5a0077b04d064c76ee714d3da7637 # v2.14.6
         with:
           category: "/language:go"
+
+  gha-workflow-security:
+    name: GHA Workflow Security
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          show-progress: 'false'
+          persist-credentials: 'false'
+      - name: Ensure GitHub action versions are pinned to SHAs
+        # uses: zgosalvez/github-actions-ensure-sha-pinned-actions@f32435541e24cd6a4700a7f52bb2ec59e80603b1 # v2.1.4
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@v2.1.4 # Test - should fail
+        with:
+          dry_run: true

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -23,7 +23,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           show-progress: 'false'
           persist-credentials: 'false'
@@ -41,7 +41,7 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           show-progress: 'false'
           persist-credentials: 'false'

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           show-progress: 'false'
           persist-credentials: 'false'
-      - uses: actions/dependency-review-action@v3
+      - uses: actions/dependency-review-action@6c5ccdad469c9f8a2996bfecaec55a631a347034 # v3.1.0
 
   codeql:
     name: CodeQL

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -76,5 +76,4 @@ jobs:
           show-progress: 'false'
           persist-credentials: 'false'
       - name: Ensure GitHub action versions are pinned to SHAs
-        # uses: zgosalvez/github-actions-ensure-sha-pinned-actions@f32435541e24cd6a4700a7f52bb2ec59e80603b1 # v2.1.4
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@v2.1.4 # Test - should fail
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@f32435541e24cd6a4700a7f52bb2ec59e80603b1 # v2.1.4

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # v1.6.0
       - name: Approve a PR if dependency semver changes are minor or patch
         if: ${{contains(fromJson('["version-update:semver-patch", "version-update:semver-minor"]'), steps.dependabot-metadata.outputs.update-type)}}
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -117,7 +117,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Get release notes
         id: get
         continue-on-error: true

--- a/.github/workflows/publish-terraform-plan.yml
+++ b/.github/workflows/publish-terraform-plan.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Find previous report comment
         id: find-comment
         if: inputs.write-comment && inputs.pr-number != ''
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
         with:
           issue-number: ${{ inputs.pr-number }}
           comment-author: 'github-actions[bot]'

--- a/.github/workflows/publish-terraform-plan.yml
+++ b/.github/workflows/publish-terraform-plan.yml
@@ -129,7 +129,7 @@ jobs:
           body-includes: Terraform Summary
       - name: Create or update comment
         if: inputs.write-comment && inputs.pr-number != ''
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -39,7 +39,7 @@ jobs:
             ./bin
             ./cover.out
             ./cover.html
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
@@ -82,7 +82,7 @@ jobs:
             ./bin
             ./cover.out
             ./cover.html
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
@@ -112,7 +112,7 @@ jobs:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
           persist-credentials: 'false'
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
@@ -138,7 +138,7 @@ jobs:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
           persist-credentials: 'false'
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
@@ -177,7 +177,7 @@ jobs:
             ./bin
             ./cover.out
             ./cover.html
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -31,7 +31,7 @@ jobs:
           show-progress: 'false'
           persist-credentials: 'false'
       - name: Restore/save Taskfile cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           key: ${{ runner.os }}-qa-taskfile
           path: |
@@ -74,7 +74,7 @@ jobs:
           show-progress: 'false'
           persist-credentials: 'false'
       - name: Restore Taskfile cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           key: ${{ runner.os }}-qa-taskfile
           path: |
@@ -169,7 +169,7 @@ jobs:
           show-progress: 'false'
           persist-credentials: 'false'
       - name: Restore Taskfile cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           key: ${{ runner.os }}-qa-taskfile
           path: |
@@ -206,7 +206,7 @@ jobs:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
           persist-credentials: 'false'
-      - uses: actions/cache@v3
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         name: Cache plugin dir
         with:
           path: .tflint.d/plugins

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -27,7 +27,6 @@ jobs:
             sum.golang.org:443
             storage.googleapis.com:443
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -211,7 +211,7 @@ jobs:
         with:
           path: .tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('terraform/.tflint.hcl') }}
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0
         name: Setup TFLint
         with:
           tflint_version: latest

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
-      - uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@e26d8975574116b0097a1161e0fe16ba75d84c1c # v1.0.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -86,7 +86,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
-      - uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@e26d8975574116b0097a1161e0fe16ba75d84c1c # v1.0.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -181,7 +181,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
-      - uses: arduino/setup-task@v1
+      - uses: arduino/setup-task@e26d8975574116b0097a1161e0fe16ba75d84c1c # v1.0.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -25,7 +25,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             sum.golang.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
@@ -68,7 +68,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             sum.golang.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
@@ -107,7 +107,7 @@ jobs:
             github.com:443
             proxy.golang.org:443
             sum.golang.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
@@ -133,7 +133,7 @@ jobs:
             github.com:443
             proxy.golang.org:443
             sum.golang.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
@@ -163,7 +163,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             sum.golang.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
@@ -201,7 +201,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -143,7 +143,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           go-version-file: go.mod
       - name: Lint with Staticcheck
-        uses: dominikh/staticcheck-action@v1.3.0
+        uses: dominikh/staticcheck-action@ba605356b4b29a60e87ab9404b712f3461e566dc # v1.3.0
         with:
           install-go: false
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           chmod +x .github/next_release_version.bash
           echo "result=$(bash .github/next_release_version.bash)" >> $GITHUB_OUTPUT
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5.24.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: "Determine next version"
         id: next_version
         run: |

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -73,7 +73,7 @@ jobs:
             registry.terraform.io:443
             releases.hashicorp.com:443
       - name: Download Terraform artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ inputs.tf-plan-artifacts-key }}
           path: ${{ github.workspace }}/terraform
@@ -86,7 +86,7 @@ jobs:
         with:
           terraform_version: ${{ steps.get_tf_version.outputs.TF_VERSION }}
       - name: Download Lambda handler artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ inputs.bin-artifacts-key }}
           path: ${{ inputs.bin-artifacts-path }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -199,7 +199,7 @@ jobs:
           rm tfplan
       - name: Store terraform artifacts
         if: success() && inputs.upload-artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ env.ARTIFACTS_KEY }}
           path: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -111,7 +111,7 @@ jobs:
             objects.githubusercontent.com:443
             registry.terraform.io:443
             releases.hashicorp.com:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.gpg-passphrase }}
       - name: Download Lambda handler artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ inputs.bin-artifacts-key }}
           path: ${{ inputs.bin-artifacts-path }}


### PR DESCRIPTION
### Closes #359

## Description

This PR updates all third-party GitHub actions which were not previously pinned to a SHA version – they are now all pinned using SHAs and a comment annotating the semver version that corresponds to the SHA. The affected actions are enumerated by individual commits on this PR's branch (see commits with messages like `GHA: pin some-org/action-name`).

Additionally, this PR includes a new job in the `code-scanning.yml` workflow that detects and fails when workflow jobs are found without a pinned SHA version. If the workflow fails, the detected action(s) will be annotated on the job summary ([example](https://github.com/usdigitalresponse/grants-ingest/actions/runs/6329514334)).

These changes are intended to promote good security hygiene for our workflows, specifically by reducing the possibility of using an action compromised by a supply-chain attack in one of our workflows. For more information, refer to the [Security hardening for GitHub Actions#Using third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) documentation from GitHub.

## Testing

For the new workflow job, review the following executions that verified expected behavior:
1. [6329474483](https://github.com/usdigitalresponse/grants-ingest/actions/runs/6329474483) Succeeds when unpinned actions are detected and `dry_run=true`.
2. [6329514334](https://github.com/usdigitalresponse/grants-ingest/actions/runs/6329514334): Failed when unpinned actions are detected and `dry_run=false`.
3. [6329532725](https://github.com/usdigitalresponse/grants-ingest/actions/runs/6329532725): Succeeds when no unpinned actions are detected.

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
