### PR TITLE
Set Datadog metric type

### DIFF
--- a/terraform/datadog_metrics.tf
+++ b/terraform/datadog_metrics.tf
@@ -39,6 +39,7 @@ resource "datadog_metric_metadata" "custom" {
   metric      = each.key
   short_name  = each.value.short_name
   description = each.value.description
+  type        = coalesce(each.value.type, "gauge")
   unit        = each.value.unit
   per_unit    = each.value.per_unit
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -177,6 +177,7 @@ variable "datadog_metrics_metadata" {
   type = map(object({
     short_name  = optional(string)
     description = optional(string)
+    type        = optional(string) # https://docs.datadoghq.com/metrics/types/ (default: "gauge")
     unit        = optional(string) # https://docs.datadoghq.com/metrics/units/
     per_unit    = optional(string)
   }))


### PR DESCRIPTION
## Description

This PR includes a slight tweak to our Terraform's `datadog_metrics_metadata` input variable structure to allow setting a `type` value for custom metrics, which conforms to the [resource](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/metric_metadata) that gets populated by this input variable. When no metric type is defined, it now defaults to `gauge`, which is the default behavior in Datadog.

This change is trivial, but the net impact will be _much_ cleaner `terraform plan` outputs from CI jobs. Currently, Terraform detects that the local value for a metric is `null`, but that the Datadog API reports the metric as having a defined type (generally `gauge`), so Terraform plans a change to the resource (e.g. `type = "gauge" -> null`), even though it has no effect on the target Datadog resource.

With these changes in-place, Terraform should no longer detect a discrepancy unless the actual metric type differs from what is configured in Terraform, which is something that should be addressed upon detection. Therefore, by removing a "perma-diff", this change makes `terraform plan` PR feedback more relevant and less likely to be ignored.

## Testing

Once the CI workflow publishes a comment to this PR containing a Terraform plan, review it to ensure metric type discrepancies are no longer reported. For an example of what we _don't_ want, refer to a historical PR's plan comment, such as [this one](https://github.com/usdigitalresponse/grants-ingest/pull/379#issuecomment-1737826389).

### Automated and Unit Tests
- [X] Added Unit tests

### Manual tests for Reviewer
- [X] Added steps to test feature/functionality manually

## Checklist
- [X] Provided ticket and description
- [X] Provided testing information
- [X] Provided adequate test coverage for all new code
- [X] Added PR reviewers
