### PR TITLE
Fix Datadog dashboard and monitor queries

### DIFF
--- a/cmd/DownloadGrantsGovDB/handler.go
+++ b/cmd/DownloadGrantsGovDB/handler.go
@@ -23,7 +23,7 @@ type ScheduledEvent struct {
 // grantsURL returns the download URL for the Grants.gov database export.
 func (e *ScheduledEvent) grantsURL() string {
 	return fmt.Sprintf("%sGrantsDBExtract%sv2.zip",
-		env.GrantsGovBaseURL + env.GrantsGovPathURL,
+		env.GrantsGovBaseURL+env.GrantsGovPathURL,
 		e.Timestamp.Format("20060102"),
 	)
 }

--- a/terraform/datadog_dashboard.tf
+++ b/terraform/datadog_dashboard.tf
@@ -105,13 +105,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:downloadffisspreadsheet}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.DownloadFFISSpreadsheet.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -244,13 +244,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:downloadgrantsgovdb}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.DownloadGrantsGovDB.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -383,13 +383,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:enqueueffisdownload}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.EnqueueFFISDownload.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -524,13 +524,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:extractgrantsgovdbtoxml}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.ExtractGrantsGovDBToXML.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -693,13 +693,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:persistffisdata}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.PersistFFISData.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -867,13 +867,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:persistgrantsgovxmldb}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.PersistGrantsGovXMLDB.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -1027,13 +1027,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:publishgrantevents}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.PublishGrantEvents.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -1577,13 +1577,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:receiveffisemail}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.ReceiveFFISEmail.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -1714,13 +1714,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:splitffisspreadsheet}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${module.SplitFFISSpreadsheet.lambda_function_name}}.as_count()"
               }
             }
 
@@ -1938,13 +1938,13 @@ resource "datadog_dashboard" "service_dashboard" {
             display_type = "bars"
 
             formula {
-              formula_expression = "invoke_success"
+              formula_expression = "invoke_total - invoke_failure"
               alias              = "Succeeded"
             }
             query {
               metric_query {
-                name  = "invoke_success"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
+                name  = "invoke_total"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.SplitGrantsGovXMLDB.lambda_function_name)}}.as_count()"
               }
             }
 

--- a/terraform/datadog_dashboard.tf
+++ b/terraform/datadog_dashboard.tf
@@ -462,7 +462,7 @@ resource "datadog_dashboard" "service_dashboard" {
         }
       }
 
-      // Shows DLQ size
+      // Shows queue size
       widget {
         timeseries_definition {
           title          = "Queue Size"
@@ -485,7 +485,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "queue_size"
-                query = "sum:aws.sqs.approximate_number_of_messages_visible{$env,$service,$version,queuename:ffis_downloads}.as_count()"
+                query = "sum:aws.sqs.approximate_number_of_messages_visible{$env,$service,$version,queuename:${lower(aws_sqs_queue.ffis_downloads.name)}}.as_count()"
               }
             }
           }
@@ -1228,7 +1228,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "queue_size"
-                query = "sum:aws.sqs.approximate_number_of_messages_visible{$env,$service,$version,queuename:publish_grant_events_dlq}.as_count()"
+                query = "sum:aws.sqs.approximate_number_of_messages_visible{$env,$service,$version,queuename:${lower(module.PublishGrantEvents.dlq_name)}}.as_count()"
               }
             }
           }

--- a/terraform/datadog_dashboard.tf
+++ b/terraform/datadog_dashboard.tf
@@ -126,7 +126,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:downloadffisspreadsheet}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.DownloadFFISSpreadsheet.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -156,7 +156,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:downloadffisspreadsheet}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.DownloadFFISSpreadsheet.lambda_function_name)}}"
               }
             }
 
@@ -171,7 +171,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:downloadffisspreadsheet}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.DownloadFFISSpreadsheet.lambda_function_name)}}"
               }
             }
           }
@@ -265,7 +265,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:downloadgrantsgovdb}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.DownloadGrantsGovDB.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -295,7 +295,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:downloadgrantsgovdb}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.DownloadGrantsGovDB.lambda_function_name)}}"
               }
             }
 
@@ -310,7 +310,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:downloadgrantsgovdb}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.DownloadGrantsGovDB.lambda_function_name)}}"
               }
             }
           }
@@ -404,7 +404,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:enqueueffisdownload}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.EnqueueFFISDownload.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -434,7 +434,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:enqueueffisdownload}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.EnqueueFFISDownload.lambda_function_name)}}"
               }
             }
 
@@ -449,7 +449,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:enqueueffisdownload}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.EnqueueFFISDownload.lambda_function_name)}}"
               }
             }
           }
@@ -545,7 +545,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:extractgrantsgovdbtoxml}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.ExtractGrantsGovDBToXML.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -575,7 +575,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:extractgrantsgovdbtoxml}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.ExtractGrantsGovDBToXML.lambda_function_name)}}"
               }
             }
 
@@ -590,7 +590,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:extractgrantsgovdbtoxml}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.ExtractGrantsGovDBToXML.lambda_function_name)}}"
               }
             }
           }
@@ -714,7 +714,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:persistffisdata}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.PersistFFISData.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -744,7 +744,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:persistffisdata}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.PersistFFISData.lambda_function_name)}}"
               }
             }
 
@@ -759,7 +759,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:persistffisdata}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.PersistFFISData.lambda_function_name)}}"
               }
             }
           }
@@ -822,13 +822,13 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invocation_total"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,handlername:persistffisdata}.as_count()"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.PersistFFISData.lambda_function_name)}}.as_count()"
               }
             }
             query {
               metric_query {
                 name  = "invocation_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:persistffisdata}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.PersistFFISData.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -888,7 +888,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:persistgrantsgovxmldb}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.PersistGrantsGovXMLDB.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -918,7 +918,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:persistgrantsgovxmldb}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.PersistGrantsGovXMLDB.lambda_function_name)}}"
               }
             }
 
@@ -933,7 +933,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:persistgrantsgovxmldb}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.PersistGrantsGovXMLDB.lambda_function_name)}}"
               }
             }
           }
@@ -1048,7 +1048,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:publishgrantevents}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.PublishGrantEvents.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -1078,7 +1078,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:publishgrantevents}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.PublishGrantEvents.lambda_function_name)}}"
               }
             }
 
@@ -1093,7 +1093,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:publishgrantevents}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.PublishGrantEvents.lambda_function_name)}}"
               }
             }
           }
@@ -1598,7 +1598,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:receiveffisemail}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.ReceiveFFISEmail.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -1628,7 +1628,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:receiveffisemail}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.ReceiveFFISEmail.lambda_function_name)}}"
               }
             }
 
@@ -1643,7 +1643,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:receiveffisemail}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.ReceiveFFISEmail.lambda_function_name)}}"
               }
             }
           }
@@ -1720,7 +1720,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_total"
-                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${module.SplitFFISSpreadsheet.lambda_function_name}}.as_count()"
+                query = "sum:aws.lambda.invocations{$env,$service,$version,functionname:${lower(module.SplitFFISSpreadsheet.lambda_function_name)}}.as_count()"
               }
             }
 
@@ -1735,7 +1735,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:splitffisspreadsheet}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.SplitFFISSpreadsheet.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -1765,7 +1765,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:splitffisspreadsheet}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.SplitFFISSpreadsheet.lambda_function_name)}}"
               }
             }
 
@@ -1780,7 +1780,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:splitffisspreadsheet}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.SplitFFISSpreadsheet.lambda_function_name)}}"
               }
             }
           }
@@ -1959,7 +1959,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_failure"
-                query = "sum:aws.lambda.errors{$env,$service,$version,handlername:splitgrantsgovxmldb}.as_count()"
+                query = "sum:aws.lambda.errors{$env,$service,$version,functionname:${lower(module.SplitGrantsGovXMLDB.lambda_function_name)}}.as_count()"
               }
             }
           }
@@ -1989,7 +1989,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_duration"
-                query = "avg:aws.lambda.duration{$env,$service,$version,handlername:splitgrantsgovxmldb}"
+                query = "avg:aws.lambda.duration{$env,$service,$version,functionname:${lower(module.SplitGrantsGovXMLDB.lambda_function_name)}}"
               }
             }
 
@@ -2004,7 +2004,7 @@ resource "datadog_dashboard" "service_dashboard" {
             query {
               metric_query {
                 name  = "invoke_timeout"
-                query = "avg:aws.lambda.timeout{$env,$service,$version,handlername:splitgrantsgovxmldb}"
+                query = "avg:aws.lambda.timeout{$env,$service,$version,functionname:${lower(module.SplitGrantsGovXMLDB.lambda_function_name)}}"
               }
             }
           }

--- a/terraform/datadog_monitors.tf
+++ b/terraform/datadog_monitors.tf
@@ -30,7 +30,7 @@ resource "datadog_monitor" "events_failed_to_publish" {
 
   query = "min(last_1h):avg:aws.sqs.approximate_number_of_messages_visible{${join(",", [
     "env:${var.environment}",
-    "queuename:${module.PublishGrantEvents.dlq_name}",
+    "queuename:${lower(module.PublishGrantEvents.dlq_name)}",
   ])}} > 0"
 
   notify_no_data   = false
@@ -53,10 +53,10 @@ resource "datadog_monitor" "DownloadGrantsGovDB-failed" {
 
   query = "sum(last_10h):sum:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.DownloadGrantsGovDB.lambda_function_name}",
+    "functionname:${lower(module.DownloadGrantsGovDB.lambda_function_name)}",
     ])}}.as_count() / sum:aws.lambda.invocations{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.DownloadGrantsGovDB.lambda_function_name}",
+    "functionname:${lower(module.DownloadGrantsGovDB.lambda_function_name)}",
   ])}}.as_count() >= 1.0"
 
   notify_no_data   = false
@@ -76,7 +76,7 @@ resource "datadog_monitor" "DownloadFFISSpreadsheet-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.DownloadFFISSpreadsheet.lambda_function_name}",
+    "functionname:${lower(module.DownloadFFISSpreadsheet.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false
@@ -96,7 +96,7 @@ resource "datadog_monitor" "EnqueueFFISSpreadsheet-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.EnqueueFFISDownload.lambda_function_name}",
+    "functionname:${lower(module.EnqueueFFISDownload.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false
@@ -116,7 +116,7 @@ resource "datadog_monitor" "ExtractGrantsGovXMLToDB-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.ExtractGrantsGovDBToXML.lambda_function_name}",
+    "functionname:${lower(module.ExtractGrantsGovDBToXML.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false
@@ -136,7 +136,7 @@ resource "datadog_monitor" "PersistFFISData-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.PersistFFISData.lambda_function_name}",
+    "functionname:${lower(module.PersistFFISData.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false
@@ -156,7 +156,7 @@ resource "datadog_monitor" "PersistGrantsGovXMLDB-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.PersistGrantsGovXMLDB.lambda_function_name}",
+    "functionname:${lower(module.PersistGrantsGovXMLDB.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false
@@ -177,7 +177,7 @@ resource "datadog_monitor" "ReceiveFFISEmail-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "functionname:${module.ReceiveFFISEmail.lambda_function_name}",
+    "functionname:${lower(module.ReceiveFFISEmail.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false
@@ -197,7 +197,7 @@ resource "datadog_monitor" "SplitFFISSpreadsheet-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "handlername:${module.SplitFFISSpreadsheet.lambda_function_name}",
+    "handlername:${lower(module.SplitFFISSpreadsheet.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false
@@ -217,7 +217,7 @@ resource "datadog_monitor" "SplitGrantsGovXMLDB-failed" {
 
   query = "sum(last_1h):avg:aws.lambda.errors{${join(",", [
     "env:${var.environment}",
-    "handlername:${module.ExtractGrantsGovDBToXML.lambda_function_name}",
+    "handlername:${lower(module.ExtractGrantsGovDBToXML.lambda_function_name)}",
   ])}}.as_count() > 0"
 
   notify_no_data   = false


### PR DESCRIPTION
### Fixes #457 

## Description

This PR fixes a few issues that are causing some of our Datadog monitors and dashboards to miss important operational issues. This was first noticed because monitors failed to alert us about failures related to #456, which on closer inspection also revealed that Lambda invocation success rates were being incorrectly represented on the service dashboard in Datadog.

All in all, there are three distinct problems that this PR addresses:
1. **Problem:** Datadog monitors (`Grant modification events failed to publish` and `DownloadGrantsGovDB failed`) failed to alert, despite the presence of DLQ messages and failed Lambda invocations.
    - **Cause:** Datadog monitor queries are case-sensitive (which is unlike dashboard queries), and most AWS metrics are tagged with lowercase values. Because we configure the monitor queries by interpolating resource names (which are mixed-case) as selector values, selectors like `queuename:grants_ingest-PublishGrantEvents-dlq` and `functionname:grants_ingest-DownloadGrantsGovDB` were not matching their intended resources, causing the queries to yield zero-count results.
    - **Solution:** Ensure that AWS resource names/identifiers are lowercased when interpolated as selector values in monitor queries. b6f4aa13df3043cbd83960d0a8cce228240c0702
2. **Problem:** The per-Lambda "Invocation Status" widgets in our service dashboard were incorrectly showing successful invocation counts (alongside correct failure counts).
    - **Cause:** The raw total invocation counts were being incorrectly represented as "Succeeded" metrics. The Lambda integration for Datadog does not provide a discrete metric for successful invocation counts – `aws.lambda.invocations` only represents total invocations, while `aws.lambda.errors` represents failed invocations.
    - **Solution:** Update the "Succeeded" bar graph to be computed as `succeeded = total - failed`. 7023760b0d29c7f697e737f1a031b0f8f73686e0
3. **Problem:** The SQS DLQ widgets in the dashboard failed to represent the presence of dead-letter queue messages.
    - **Cause:** The queue name used as a selector in the query was improperly configured as an inadvertent result of #360.
    - **Solution:** Replace the (incorrect) hard-coded queue name in the dashboard query with the lowercased output value of `module.PublishGrantEvents.dlq_name`, which correctly identifies the SQS resource in Datadog. afc72475ee0a8ec7b6ef3b82f568673967bb96f1

Additionally, this PR updates all dashboard queries that were using hard-coded values for the `handlername:` (custom tag) selector to instead use the native `functionname:` provided by the Lambda integration. This is mostly a cleanup effort, but given the issues with hard-coding resource names described above, this seemed like a good impetus to make the change.

## Testing

_Note:_ A subset of these changes were manually tested on Datadog draft resources in order to confirm the issues and viability of their corresponding solutions.

1. Check the Terraform plan comment on this PR (which will be published by a CI job soon after the PR is opened) to ensure that the changes look correct.
2. Once this PR is merged to Staging, check the `(Draft - staging)` Datadog resources to confirm they are still working. Additionally, inspect historical data on the dasboard and monitors to confirm they are accurately representing the failure scenarios addressed by #458.

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
