### PR TITLE
Bypass config resolution for localstack

### DIFF
--- a/internal/awsHelpers/config.go
+++ b/internal/awsHelpers/config.go
@@ -17,6 +17,7 @@ import (
 // If no $LOCALSTACK_HOSTNAME variable exists in the current environment, the resolver falls
 // back to the SDK's default endpoint resolution behavior.
 func GetConfig(ctx context.Context) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx)
 	optionsFunc := func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 		if lsHostname, isSet := os.LookupEnv("LOCALSTACK_HOSTNAME"); isSet {
 			lsPort := "4566"


### PR DESCRIPTION
### Ticket #496 

## Description

This PR contains changes that bypass customizations involving `github.com/aws/aws-sdk-go-v2/config` that provide LocalStack compatibility. The immediate goal is to resolve the issues noted in #496; if it does so, additional changes will be necessary to restore the ability to use LocalStack in dev environments.