### PR TITLE
chore: upgrade datadog-lambda-extension 41 -> 51

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -169,7 +169,7 @@ variable "datadog_lambda_custom_tags" {
 variable "datadog_lambda_extension_version" {
   description = "Version to use for the Datadog Lambda Extension layer (when var.datadog_enabled is true)."
   type        = string
-  default     = "41"
+  default     = "51"
 }
 
 variable "datadog_metrics_metadata" {


### PR DESCRIPTION
### Ticket #496 

## Description

This PR upgrades the [`datadog-lambda-extension` layer](https://github.com/DataDog/datadog-lambda-extension), which may be contributing to the problems related to #496.