### PR TITLE
Update release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,11 +13,9 @@
 #   - $PATCH will always be 0 (and is not used in this template)
 
 version-template: '$MAJOR.$MINOR'
-
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'release/$RESOLVED_VERSION'
 tag-prefix: 'release/'
-version-template: '2023.$MINOR'
 version-resolver:
   default: minor
 prerelease: true

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,19 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/release-drafter/release-drafter/ff929b5ceb21bf2646a216e916f9a8bb507d48a3/schema.json
+
+# NOTES:
+# - The value of the `version` action input is NOT made directly available to this template.
+# - Components like $MAJOR/$MINOR/$PATCH are derived either by parsing the `version` action input
+#   or else computed by incrementing the previous release if no `version` input is given.
+# - $RESOLVED_VERSION is the result of rendering the below `version-template` config value
+#   once the individual version number components have been derived.
+# - We compute our YYYY.inc versions separately and passed the result as `version` input;
+#   while it is NOT incremented by this action, it is still parsed into components, where:
+#   - $MAJOR = YYYY value of `version` input
+#   - $MINOR = inc value of `version` input
+#   - $PATCH will always be 0 (and is not used in this template)
+
+version-template: '$MAJOR.$MINOR'
+
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'release/$RESOLVED_VERSION'
 tag-prefix: 'release/'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,13 +5,43 @@ on:
     branches:
       - main
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types:
+      - opened
+      - synchronize
+      - reopened
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  update_release_draft:
+  label_pull_requests:
+    name: "Label pull requests"
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+      - name: "Run auto-labeler"
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.25.0
+        with:
+          disable-releaser: true
+          disable-autolabeler: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  draft_release:
+    name: Create or update next release draft
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
       pull-requests: write
@@ -26,13 +56,27 @@ jobs:
             api.github.com:443
             github.com:443
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: "Determine next version"
-        id: next_version
+        with:
+          show-progress: false
+          persist-credentials: 'false'
+      - name: Get tag of "latest" release
+        id: latest_release
+        run: echo "tag=$(gh release view --json tagName --jq .tagName)" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Determine next release version"
+        id: next_release
         run: |
           chmod +x .github/next_release_version.bash
-          echo "result=$(bash .github/next_release_version.bash)" >> $GITHUB_OUTPUT
-      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.25.0
+          echo "version=$(bash .github/next_release_version.bash $LATEST_TAG)" >> $GITHUB_OUTPUT
+        env:
+          LATEST_TAG: ${{ steps.latest_release.outputs.tag || '' }}
+      - name: "Generate release notes and label pull requests"
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.25.0
+        with:
+          version: ${{ steps.next_release.outputs.version }}
+          publish: false
+          disable-releaser: false
+          disable-autolabeler: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          version: ${{ steps.next_version.outputs.result }}


### PR DESCRIPTION
## Description

This PR mirrors the changes to `.github/release-drafter.yml` in https://github.com/usdigitalresponse/usdr-gost/pull/2436, which remove the need to maintain a hard-coded year in that file, as well as adds a `# NOTES:` comment to the same file, which hopefully clarifies how the `release-drafter` action incorporates our precomputed `YYYY.inc` into the resulting release name and tag.

Additionally, this PR splits the `.github/workflows/release-drafter.yml` workflow file into two distinct jobs: one that labels open PRs, and another that creates/updates draft releases. This follows more recently-established conventions in other repositories; in particular it avoids modifying release notes in reaction to pull request events, which is unnecessary in the context of a PR.