### PR TITLE
Ingest forecasted opportunities

### DIFF
--- a/cmd/SplitGrantsGovXMLDB/handler.go
+++ b/cmd/SplitGrantsGovXMLDB/handler.go
@@ -157,7 +157,7 @@ func readRecords(ctx context.Context, r io.Reader, ch chan<- grantRecord) error 
 				if err = d.DecodeElement(&o, &se); err == nil {
 					ch <- &o
 				}
-			} else if se.Name.Local == GRANT_FORECAST_XML_NAME {
+			} else if se.Name.Local == GRANT_FORECAST_XML_NAME && env.IsForecastedGrantsEnabled {
 				var f forecast
 				if err = d.DecodeElement(&f, &se); err == nil {
 					ch <- &f

--- a/cmd/SplitGrantsGovXMLDB/handler_test.go
+++ b/cmd/SplitGrantsGovXMLDB/handler_test.go
@@ -216,7 +216,7 @@ func TestLambdaInvocationScenarios(t *testing.T) {
 					"2345",
 					now.AddDate(-1, 0, 0).Format("01022006"),
 					false,
-					false,
+					true,
 					true,
 				},
 			},
@@ -319,17 +319,7 @@ func TestLambdaInvocationScenarios(t *testing.T) {
 			},
 		},
 	} {
-		// Configure forecasted flag in environment variables
-		if tt.isForecastedGrantsEnabled {
-			goenv.Unmarshal(goenv.EnvSet{
-				"IS_FORECASTED_GRANTS_ENABLED": "true",
-			}, &env)
-		} else {
-			goenv.Unmarshal(goenv.EnvSet{
-				"IS_FORECASTED_GRANTS_ENABLED": "false",
-			}, &env)
-		}
-
+		env.IsForecastedGrantsEnabled = tt.isForecastedGrantsEnabled
 		var sourceGrantsData bytes.Buffer
 		sourceOpportunitiesData := make(map[string][]byte)
 		_, err := sourceGrantsData.WriteString("<Grants>")

--- a/cmd/SplitGrantsGovXMLDB/main.go
+++ b/cmd/SplitGrantsGovXMLDB/main.go
@@ -27,12 +27,13 @@ import (
 )
 
 type Environment struct {
-	LogLevel             string `env:"LOG_LEVEL,default=INFO"`
-	DownloadChunkLimit   int64  `env:"DOWNLOAD_CHUNK_LIMIT,default=10"`
-	DestinationBucket    string `env:"GRANTS_PREPARED_DATA_BUCKET_NAME,required=true"`
-	MaxConcurrentUploads int    `env:"MAX_CONCURRENT_UPLOADS,default=1"`
-	UsePathStyleS3Opt    bool   `env:"S3_USE_PATH_STYLE,default=false"`
-	Extras               goenv.EnvSet
+	LogLevel                  string `env:"LOG_LEVEL,default=INFO"`
+	DownloadChunkLimit        int64  `env:"DOWNLOAD_CHUNK_LIMIT,default=10"`
+	DestinationBucket         string `env:"GRANTS_PREPARED_DATA_BUCKET_NAME,required=true"`
+	MaxConcurrentUploads      int    `env:"MAX_CONCURRENT_UPLOADS,default=1"`
+	UsePathStyleS3Opt         bool   `env:"S3_USE_PATH_STYLE,default=false"`
+	IsForecastedGrantsEnabled bool   `env:"IS_FORECASTED_GRANTS_ENABLED,default=false"`
+	Extras                    goenv.EnvSet
 }
 
 var (

--- a/cmd/SplitGrantsGovXMLDB/types.go
+++ b/cmd/SplitGrantsGovXMLDB/types.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+
+	"github.com/usdigitalresponse/grants-ingest/internal/log"
+	grantsgov "github.com/usdigitalresponse/grants-ingest/pkg/grantsSchemas/grants.gov"
+)
+
+type grantRecord interface {
+	logWith(log.Logger) log.Logger
+	// s3ObjectKey returns a string to use as the object key when saving the opportunity to an S3 bucket
+	s3ObjectKey() string
+	lastModified() (time.Time, error)
+	toXML() ([]byte, error)
+}
+
+type opportunity grantsgov.OpportunitySynopsisDetail_1_0
+
+func (o opportunity) logWith(logger log.Logger) log.Logger {
+	return log.With(logger,
+		"opportunity_id", o.OpportunityID,
+		"opportunity_number", o.OpportunityNumber,
+		"is_forecast", false,
+	)
+}
+
+func (o opportunity) s3ObjectKey() string {
+	return fmt.Sprintf("%s/%s/grants.gov/v2.OpportunitySynopsisDetail_1_0.xml",
+		o.OpportunityID[0:3], o.OpportunityID,
+	)
+}
+
+func (o opportunity) lastModified() (time.Time, error) {
+	return o.LastUpdatedDate.Time()
+}
+
+func (o opportunity) toXML() ([]byte, error) {
+	return xml.Marshal(grantsgov.OpportunitySynopsisDetail_1_0(o))
+}
+
+type forecast grantsgov.OpportunityForecastDetail_1_0
+
+func (f forecast) logWith(logger log.Logger) log.Logger {
+	return log.With(logger,
+		"opportunity_id", f.OpportunityID,
+		"opportunity_number", f.OpportunityNumber,
+		"is_forecast", true,
+	)
+}
+
+func (f forecast) s3ObjectKey() string {
+	return fmt.Sprintf("%s/%s/grants.gov/v2.OpportunityForecastDetail_1_0.xml",
+		f.OpportunityID[0:3], f.OpportunityID,
+	)
+}
+
+func (f forecast) lastModified() (time.Time, error) {
+	return f.LastUpdatedDate.Time()
+}
+
+func (f forecast) toXML() ([]byte, error) {
+	return xml.Marshal(grantsgov.OpportunityForecastDetail_1_0(f))
+}

--- a/cmd/SplitGrantsGovXMLDB/types_test.go
+++ b/cmd/SplitGrantsGovXMLDB/types_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpportunityS3ObjectKey(t *testing.T) {
+	opp := &opportunity{OpportunityID: "123456789"}
+	assert.Equal(t, opp.s3ObjectKey(), "123/123456789/grants.gov/v2.OpportunitySynopsisDetail_1_0.xml")
+}
+
+func TestForecastS3ObjectKey(t *testing.T) {
+	f := &forecast{OpportunityID: "123456789"}
+	assert.Equal(t, f.s3ObjectKey(), "123/123456789/grants.gov/v2.OpportunityForecastDetail_1_0.xml")
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -441,7 +441,7 @@ resource "aws_s3_bucket_notification" "grant_prepared_data" {
   lambda_function {
     lambda_function_arn = module.PersistGrantsGovXMLDB.lambda_function_arn
     events              = ["s3:ObjectCreated:*"]
-    filter_suffix       = "/grants.gov/v2.xml"
+    filter_suffix       = "/grants.gov/v2.OpportunitySynopsisDetail_1_0.xml"
   }
 
   lambda_function {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -441,6 +441,12 @@ resource "aws_s3_bucket_notification" "grant_prepared_data" {
   lambda_function {
     lambda_function_arn = module.PersistGrantsGovXMLDB.lambda_function_arn
     events              = ["s3:ObjectCreated:*"]
+    filter_suffix       = "/grants.gov/v2.xml"
+  }
+
+  lambda_function {
+    lambda_function_arn = module.PersistGrantsGovXMLDB.lambda_function_arn
+    events              = ["s3:ObjectCreated:*"]
     filter_suffix       = "/grants.gov/v2.OpportunitySynopsisDetail_1_0.xml"
   }
 

--- a/terraform/modules/SplitGrantsGovXMLDB/main.tf
+++ b/terraform/modules/SplitGrantsGovXMLDB/main.tf
@@ -106,6 +106,7 @@ module "lambda_function" {
     GRANTS_PREPARED_DATA_BUCKET_NAME = data.aws_s3_bucket.prepared_data.id
     LOG_LEVEL                        = var.log_level
     MAX_CONCURRENT_UPLOADS           = "10"
+    IS_FORECASTED_GRANTS_ENABLED     = var.is_forecasted_grants_enabled
   })
 
   allowed_triggers = {

--- a/terraform/modules/SplitGrantsGovXMLDB/variables.tf
+++ b/terraform/modules/SplitGrantsGovXMLDB/variables.tf
@@ -86,3 +86,9 @@ variable "grants_prepared_data_bucket_name" {
   description = "Name of the S3 bucket used to store grants prepared data."
   type        = string
 }
+
+variable "is_forecasted_grants_enabled" {
+  description = "Flag to control whether forecasted grants should be processed and stored in S3."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### Ticket #330 

## Description

This PR refactors the `SplitGrantsGovXMLDB` lambda function so it ingests both grant opportunities and forecasted grants. 

As the lambda is scanning through the extracted grants.gov XML, it will now identify both `OpportunitySynopsisDetail_1_0` and `OpportunityForecastDetail_1_0` XML tags (whereas it previously only identified the former). These individual XML records will still be stashed as individual S3 files, but now with updated filenames to distinguish forecasted vs not. 

For now, we're also updating the filtering for the downstream `PersistGrantsGovXMLDB` lambda, so it only picks up on opportunities (not forecasted). Future work will enable forecasted grants through the rest of the pipeline. 

## Testing
- Added/updated unit tests to ensure it processes forecasted grants
- I'd like to verify in awslocal that the lambda runs and stashes the expected S3 objects for forecasted grants, but I'm struggling to get that working properly... I'll try to work on that with ty before merging

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers
