### PR TITLE
Fix `openapi/openapi.yaml` over-indentation

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5,333 +5,333 @@ info:
 paths: {} # No endpoints defined
 components:
   schemas:
-      AdditionalInformation:
-        type: object
-        properties:
-          eligibility:
+    AdditionalInformation:
+      type: object
+      properties:
+        eligibility:
+          type: string
+        text:
+          type: string
+        url:
+          type: string
+          format: uri
+    Agency:
+      type: object
+      properties:
+        code:
+          type: string
+        name:
+          type: string
+    Applicant:
+      type: object
+      properties:
+        name:
+          type: string
+          enum:
+            - 'State governments'
+            - 'County governments'
+            - 'City or township governments'
+            - 'Special district governments'
+            - 'Independent school districts'
+            - 'Public and State controlled institutions of higher education'
+            - 'Native American tribal governments (Federally recognized)'
+            - 'Public housing authorities/Indian housing authorities'
+            - 'Native American tribal organizations (other than Federally recognized tribal governments)'
+            - 'Nonprofits having a 501(c)(3) status with the IRS, other than institutions of higher education'
+            - 'Nonprofits that do not have a 501(c)(3) status with the IRS, other than institutions of higher education'
+            - 'Private institutions of higher education'
+            - 'Individuals'
+            - 'For profit organizations other than small businesses'
+            - 'Small businesses'
+            - 'Others (see text field entitled "Additional Information on Eligibility" for clarification)'
+            - 'Unrestricted (i.e., open to any type of entity above), subject to any clarification in text field entitled "Additional Information on Eligibility'
+        code:
+          type: string
+          enum:
+            - '00'
+            - '01'
+            - '02'
+            - '04'
+            - '05'
+            - '06'
+            - '07'
+            - '08'
+            - '11'
+            - '12'
+            - '13'
+            - '20'
+            - '21'
+            - '22'
+            - '23'
+            - '25'
+            - '99'
+    Award:
+      type: object
+      properties:
+        ceiling:
+          type: string
+        floor:
+          type: string
+        estimated_total_program_funding:
+          type: string
+        expected_number_of_awards:
+          type: number
+      required:
+        - ceiling
+        - floor
+    CloseDate:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        explanation:
+          type: string
+    Email:
+      type: object
+      properties:
+        address:
+          type: string
+          format: email
+        description:
+          type: string
+    FundingActivityCategory:
+      type: object
+      properties:
+        name:
+          type: string
+          enum:
+            - 'Recovery Act'
+            - 'Agriculture'
+            - 'Arts'
+            - 'Business and Commerce'
+            - 'Community Development'
+            - 'Consumer Protection'
+            - 'Disaster Prevention and Relief'
+            - 'Education'
+            - 'Employment, Labor and Training'
+            - 'Energy'
+            - 'Environment'
+            - 'Food and Nutrition'
+            - 'Health'
+            - 'Housing'
+            - 'Humanities'
+            - 'Infrastructure Investment and Jobs Act'
+            - 'Information and Statistics'
+            - 'Income Security and Social Services'
+            - 'Law, Justice and Legal Services'
+            - 'Natural Resources'
+            - 'Other'
+            - 'Opportunity Zone Benefits'
+            - 'Regional Development'
+            - 'Science and Technology and Other Research and Development'
+            - 'Transportation'
+            - 'Affordable Care Act'
+        code:
+          type: string
+          enum:
+            - 'RA'
+            - 'AG'
+            - 'AR'
+            - 'BC'
+            - 'CD'
+            - 'CP'
+            - 'DPR'
+            - 'ED'
+            - 'ELT'
+            - 'EN'
+            - 'ENV'
+            - 'FN'
+            - 'HL'
+            - 'HO'
+            - 'HU'
+            - 'IIJ'
+            - 'IS'
+            - 'ISS'
+            - 'LJL'
+            - 'NR'
+            - 'O'
+            - 'OZ'
+            - 'RD'
+            - 'ST'
+            - 'T'
+            - 'ACA'
+    FundingActivity:
+      type: object
+      properties:
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/FundingActivityCategory'
+          minItems: 1
+        explanation:
+          type: string
+          nullable: true
+    FundingInstrument:
+      type: object
+      properties:
+        name:
+          type: string
+          enum:
+            - 'Cooperative Agreement'
+            - 'Grant'
+            - 'Procurement Contract'
+            - 'Other'
+        code:
+          type: string
+          enum:
+            - 'CA'
+            - 'G'
+            - 'PC'
+            - 'O'
+    GrantorContact:
+      type: object
+      properties:
+        email:
+          $ref: '#/components/schemas/Email'
+        text:
+          type: string
+    Metadata:
+      type: object
+      properties:
+        version:
+          type: string
+    OpportunityCategory:
+      type: object
+      properties:
+        name:
+          type: string
+          enum:
+            - 'Discretionary'
+            - 'Mandatory'
+            - 'Continuation'
+            - 'Earmark'
+            - 'Other'
+        code:
+          type: string
+          enum:
+            - 'D'
+            - 'M'
+            - 'C'
+            - 'E'
+            - 'O'
+        explanation:
+          type: string
+    Opportunity:
+      type: object
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        category:
+          $ref: '#/components/schemas/OpportunityCategory'
+        last_updated:
+          type: string
+          format: date
+        milestones:
+          $ref: '#/components/schemas/OpportunityMilestones'
+      required:
+        - id
+        - number
+        - title
+        - last_updated
+        - milestones
+    OpportunityMilestones:
+      type: object
+      properties:
+        post_date:
+          type: string
+          format: date
+        archive_date:
+          type: string
+          format: date
+        close:
+          $ref: '#/components/schemas/CloseDate'
+      required:
+        - post_date
+    ULIDType:
+      type: string
+      format: ulid
+    Revision:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ULIDType'
+        timestamp:
+          type: string
+          format: date-time
+    Grant:
+      type: object
+      properties:
+        description:
+          type: string
+        funding_instrument_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/FundingInstrument'
+          minItems: 1
+        cost_sharing_or_matching_requirement:
+          type: boolean
+        cfda_numbers:
+          type: array
+          items:
             type: string
-          text:
-            type: string
-          url:
-            type: string
-            format: uri
-      Agency:
-        type: object
-        properties:
-          code:
-            type: string
-          name:
-            type: string
-      Applicant:
-        type: object
-        properties:
-          name:
-            type: string
-            enum:
-              - 'State governments'
-              - 'County governments'
-              - 'City or township governments'
-              - 'Special district governments'
-              - 'Independent school districts'
-              - 'Public and State controlled institutions of higher education'
-              - 'Native American tribal governments (Federally recognized)'
-              - 'Public housing authorities/Indian housing authorities'
-              - 'Native American tribal organizations (other than Federally recognized tribal governments)'
-              - 'Nonprofits having a 501(c)(3) status with the IRS, other than institutions of higher education'
-              - 'Nonprofits that do not have a 501(c)(3) status with the IRS, other than institutions of higher education'
-              - 'Private institutions of higher education'
-              - 'Individuals'
-              - 'For profit organizations other than small businesses'
-              - 'Small businesses'
-              - 'Others (see text field entitled "Additional Information on Eligibility" for clarification)'
-              - 'Unrestricted (i.e., open to any type of entity above), subject to any clarification in text field entitled "Additional Information on Eligibility'
-          code:
-            type: string
-            enum:
-              - '00'
-              - '01'
-              - '02'
-              - '04'
-              - '05'
-              - '06'
-              - '07'
-              - '08'
-              - '11'
-              - '12'
-              - '13'
-              - '20'
-              - '21'
-              - '22'
-              - '23'
-              - '25'
-              - '99'
-      Award:
-        type: object
-        properties:
-          ceiling:
-            type: string
-          floor:
-            type: string
-          estimated_total_program_funding:
-            type: string
-          expected_number_of_awards:
-            type: number
-        required:
-          - ceiling
-          - floor
-      CloseDate:
-        type: object
-        properties:
-          date:
-            type: string
-            format: date
-          explanation:
-            type: string
-      Email:
-        type: object
-        properties:
-          address:
-            type: string
-            format: email
-          description:
-            type: string
-      FundingActivityCategory:
-        type: object
-        properties:
-          name:
-            type: string
-            enum:
-              - 'Recovery Act'
-              - 'Agriculture'
-              - 'Arts'
-              - 'Business and Commerce'
-              - 'Community Development'
-              - 'Consumer Protection'
-              - 'Disaster Prevention and Relief'
-              - 'Education'
-              - 'Employment, Labor and Training'
-              - 'Energy'
-              - 'Environment'
-              - 'Food and Nutrition'
-              - 'Health'
-              - 'Housing'
-              - 'Humanities'
-              - 'Infrastructure Investment and Jobs Act'
-              - 'Information and Statistics'
-              - 'Income Security and Social Services'
-              - 'Law, Justice and Legal Services'
-              - 'Natural Resources'
-              - 'Other'
-              - 'Opportunity Zone Benefits'
-              - 'Regional Development'
-              - 'Science and Technology and Other Research and Development'
-              - 'Transportation'
-              - 'Affordable Care Act'
-          code:
-            type: string
-            enum:
-              - 'RA'
-              - 'AG'
-              - 'AR'
-              - 'BC'
-              - 'CD'
-              - 'CP'
-              - 'DPR'
-              - 'ED'
-              - 'ELT'
-              - 'EN'
-              - 'ENV'
-              - 'FN'
-              - 'HL'
-              - 'HO'
-              - 'HU'
-              - 'IIJ'
-              - 'IS'
-              - 'ISS'
-              - 'LJL'
-              - 'NR'
-              - 'O'
-              - 'OZ'
-              - 'RD'
-              - 'ST'
-              - 'T'
-              - 'ACA'
-      FundingActivity:
-        type: object
-        properties:
-          categories:
-            type: array
-            items:
-              $ref: '#/components/schemas/FundingActivityCategory'
-            minItems: 1
-          explanation:
-            type: string
-            nullable: true
-      FundingInstrument:
-        type: object
-        properties:
-          name:
-            type: string
-            enum:
-              - 'Cooperative Agreement'
-              - 'Grant'
-              - 'Procurement Contract'
-              - 'Other'
-          code:
-            type: string
-            enum:
-              - 'CA'
-              - 'G'
-              - 'PC'
-              - 'O'
-      GrantorContact:
-        type: object
-        properties:
-          email:
-            $ref: '#/components/schemas/Email'
-          text:
-            type: string
-      Metadata:
-        type: object
-        properties:
-          version:
-            type: string
-      OpportunityCategory:
-        type: object
-        properties:
-          name:
-            type: string
-            enum:
-              - 'Discretionary'
-              - 'Mandatory'
-              - 'Continuation'
-              - 'Earmark'
-              - 'Other'
-          code:
-            type: string
-            enum:
-              - 'D'
-              - 'M'
-              - 'C'
-              - 'E'
-              - 'O'
-          explanation:
-            type: string
-      Opportunity:
-        type: object
-        properties:
-          id:
-            type: string
-          number:
-            type: string
-          title:
-            type: string
-          description:
-            type: string
-          category:
-            $ref: '#/components/schemas/OpportunityCategory'
-          last_updated:
-            type: string
-            format: date
-          milestones:
-            $ref: '#/components/schemas/OpportunityMilestones'
-        required:
-          - id
-          - number
-          - title
-          - last_updated
-          - milestones
-      OpportunityMilestones:
-        type: object
-        properties:
-          post_date:
-            type: string
-            format: date
-          archive_date:
-            type: string
-            format: date
-          close:
-            $ref: '#/components/schemas/CloseDate'
-        required:
-          - post_date
-      ULIDType:
-        type: string
-        format: ulid
-      Revision:
-        type: object
-        properties:
-          id:
-            $ref: '#/components/schemas/ULIDType'
-          timestamp:
-            type: string
-            format: date-time
-      Grant:
-        type: object
-        properties:
-          description:
-            type: string
-          funding_instrument_types:
-            type: array
-            items:
-              $ref: '#/components/schemas/FundingInstrument'
-            minItems: 1
-          cost_sharing_or_matching_requirement:
-            type: boolean
-          cfda_numbers:
-            type: array
-            items:
-              type: string
-            minItems: 1
-          bill:
-            type: string
-          eligible_applicants:
-            type: array
-            items:
-              $ref: '#/components/schemas/Applicant'
-            minItems: 1
-          additional_information:
-            $ref: '#/components/schemas/AdditionalInformation'
-          agency:
-            $ref: '#/components/schemas/Agency'
-          award:
-            $ref: '#/components/schemas/Award'
-          funding_activity:
-            $ref: '#/components/schemas/FundingActivity'
-          grantor:
-            $ref: '#/components/schemas/GrantorContact'
-          metadata:
-            $ref: '#/components/schemas/Metadata'
-          opportunity:
-            $ref: '#/components/schemas/Opportunity'
-          revision:
-            $ref: '#/components/schemas/ULIDType'
-        required:
-          - funding_instrument_types
-          - funding_activity
-          - cost_sharing_or_matching_requirement
-          - grantor
-          - eligible_applicants
-          - description
-          - cfda_numbers
-          - opportunity
-          - revision
-      GrantModificationEvent:
-        type: object
-        properties:
-          type:
-            type: string
-            enum:
-              - create
-              - update
-              - delete
-          versions:
-            type: object
-            properties:
-              new:
-                anyOf:
-                  - type: 'null'
-                  - $ref: '#/components/schemas/Grant'
-              previous:
-                anyOf:
-                  - type: 'null'
-                  - $ref: '#/components/schemas/Grant'
+          minItems: 1
+        bill:
+          type: string
+        eligible_applicants:
+          type: array
+          items:
+            $ref: '#/components/schemas/Applicant'
+          minItems: 1
+        additional_information:
+          $ref: '#/components/schemas/AdditionalInformation'
+        agency:
+          $ref: '#/components/schemas/Agency'
+        award:
+          $ref: '#/components/schemas/Award'
+        funding_activity:
+          $ref: '#/components/schemas/FundingActivity'
+        grantor:
+          $ref: '#/components/schemas/GrantorContact'
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        opportunity:
+          $ref: '#/components/schemas/Opportunity'
+        revision:
+          $ref: '#/components/schemas/ULIDType'
+      required:
+        - funding_instrument_types
+        - funding_activity
+        - cost_sharing_or_matching_requirement
+        - grantor
+        - eligible_applicants
+        - description
+        - cfda_numbers
+        - opportunity
+        - revision
+    GrantModificationEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - create
+            - update
+            - delete
+        versions:
+          type: object
+          properties:
+            new:
+              anyOf:
+                - type: 'null'
+                - $ref: '#/components/schemas/Grant'
+            previous:
+              anyOf:
+                - type: 'null'
+                - $ref: '#/components/schemas/Grant'


### PR DESCRIPTION
### Relates to #887 

## Description

This PR simply de-indents the YAML block under `components.schemas` by 2 spaces (from 4 spaces) in `openapi/openapi.yaml`. Although syntactically correct (all sub-objects of `components.schemas` are indented 4 spaces relative to the the parent block depth), the indentation is inconsistent with other blocks in the same file, and overall is inconsistent with recommended YAML formatting configurations currently under consideration in #894. 

The main motivation for this PR is to provide a reviewability improvement for #887, which also includes these same de-indentation changes. The idea is that if this PR is merged to `main` first, then the `openapi/openapi.yaml` diff in #887 will more accurately reflect the important modifications to that file.
