### PR TITLE
Fix: missing taskfile source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           show-progress: 'false'
           persist-credentials: 'false'
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.taskfiles/local.yml
+++ b/.taskfiles/local.yml
@@ -1,3 +1,4 @@
+---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
 # https://taskfile.dev
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,7 +7,9 @@ version: '3'
 output: prefixed
 
 includes:
-  local: .taskfiles/local.yml
+  local:
+    taskfile: .taskfiles/local.yml
+    optional: true
 
 tasks:
   default:


### PR DESCRIPTION
### Relates to #894 

## Description

This PR fixes a build automation failure introduced in #894. That PR added a new Taskfile (`.taskfiles/local.yml`), which isn't bundled as a build source in `.github/workflows/build.yml`. Since it isn't available in build environments, the `task` command fails because it cannot locate the file. To fix this, there are two options:
1. Update the CI/CD build workflow to include `.taskfiles/local.yml` in build environments.
2. Update `Taskfile.yml` so that `.taskfiles/local.yml` is marked as an [optional include](https://taskfile.dev/usage/#optional-includes) so that `task` won't fail when the included file is unavailable.

Since nothing in `.taskfiles/local.yml` is strictly necessary outside of local development usage, this PR implements the second option.