### PR TITLE
Fix: Handle missing `LastUpdatedDate` attribute in DynamoDB items

### DIFF
--- a/cmd/SplitGrantsGovXMLDB/dynamodb.go
+++ b/cmd/SplitGrantsGovXMLDB/dynamodb.go
@@ -38,6 +38,9 @@ func GetDynamoDBLastModified(ctx context.Context, c DynamoDBGetItemAPI, table st
 	if err := attributevalue.UnmarshalMap(resp.Item, &item); err != nil {
 		return nil, err
 	}
+	if item.LastUpdatedDate == "" {
+		return nil, nil
+	}
 	lastUpdatedDate, err := item.LastUpdatedDate.Time()
 	return &lastUpdatedDate, err
 }

--- a/cmd/SplitGrantsGovXMLDB/handler_test.go
+++ b/cmd/SplitGrantsGovXMLDB/handler_test.go
@@ -627,18 +627,80 @@ func TestProcessRecord(t *testing.T) {
 		assert.ErrorContains(t, err, "Error uploading prepared grant record to S3")
 	})
 
-	t.Run("matching LastUpdatedDate skips upload to S3", func(t *testing.T) {
+	t.Run("skips S3 upload when DDB item LastUpdatedDate equals record", func(t *testing.T) {
 		setupLambdaEnvForTesting(t)
+		putObjectCalled := false
 		s3Client := mockPutObjectAPI(func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
-			t.Helper()
-			require.Fail(t, "PutObject called unexpectedly")
-			return nil, fmt.Errorf("PutObject called unexpectedly")
+			putObjectCalled = true
+			return nil, nil
 		})
-		ddb := mockDDBClientGetItemCollection([]mockDDBClientGetItemReturnValue{{
+		ddb := mockDDBClientGetItemCollection{{
 			GrantId:          string(testOpportunity.OpportunityID),
 			ItemLastModified: string(testOpportunity.LastUpdatedDate),
-		}})
+		}}
 		err := processRecord(context.TODO(), s3Client, ddb.NewGetItemClient(t), testOpportunity)
 		assert.NoError(t, err)
+		assert.False(t, putObjectCalled, "PutObject called unexpectedly")
+	})
+
+	t.Run("skips S3 upload when DDB item LastUpdatedDate is future", func(t *testing.T) {
+		setupLambdaEnvForTesting(t)
+		putObjectCalled := false
+		s3Client := mockPutObjectAPI(func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+			putObjectCalled = true
+			return nil, nil
+		})
+		ddb := mockDDBClientGetItemCollection{{
+			GrantId:          string(testOpportunity.OpportunityID),
+			ItemLastModified: now.Add(24 * time.Hour).Format(grantsgov.TimeLayoutMMDDYYYYType),
+		}}
+		err := processRecord(context.TODO(), s3Client, ddb.NewGetItemClient(t), testOpportunity)
+		assert.NoError(t, err)
+		assert.False(t, putObjectCalled, "PutObject called unexpectedly")
+	})
+
+	t.Run("uploads to S3 when DDB item LastUpdatedDate is missing or blank", func(t *testing.T) {
+		setupLambdaEnvForTesting(t)
+		putObjectCalled := false
+		s3Client := mockPutObjectAPI(func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+			putObjectCalled = true
+			return nil, nil
+		})
+		ddb := mockDDBClientGetItemCollection{{
+			GrantId:          string(testOpportunity.OpportunityID),
+			ItemLastModified: "",
+		}}
+		err := processRecord(context.TODO(), s3Client, ddb.NewGetItemClient(t), testOpportunity)
+		assert.NoError(t, err)
+		assert.True(t, putObjectCalled, "PutObject should have been called")
+	})
+
+	t.Run("uploads to S3 when DDB item LastUpdatedDate is outdated", func(t *testing.T) {
+		setupLambdaEnvForTesting(t)
+		putObjectCalled := false
+		s3Client := mockPutObjectAPI(func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+			putObjectCalled = true
+			return nil, nil
+		})
+		ddb := mockDDBClientGetItemCollection{{
+			GrantId:          string(testOpportunity.OpportunityID),
+			ItemLastModified: now.Add(-24 * time.Hour).Format(grantsgov.TimeLayoutMMDDYYYYType),
+		}}
+		err := processRecord(context.TODO(), s3Client, ddb.NewGetItemClient(t), testOpportunity)
+		assert.NoError(t, err)
+		assert.True(t, putObjectCalled, "PutObject should have been called")
+	})
+
+	t.Run("uploads to S3 when DDB item is missing", func(t *testing.T) {
+		setupLambdaEnvForTesting(t)
+		putObjectCalled := false
+		s3Client := mockPutObjectAPI(func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+			putObjectCalled = true
+			return nil, nil
+		})
+		ddb := mockDDBClientGetItemCollection{}
+		err := processRecord(context.TODO(), s3Client, ddb.NewGetItemClient(t), testOpportunity)
+		assert.NoError(t, err)
+		assert.True(t, putObjectCalled, "PutObject should have been called")
 	})
 }


### PR DESCRIPTION
### Ticket #878

## Description

This PR addresses a condition where a DynamoDB item has no `LastUpdatedDate` attribute, which can happen when FFIS data for a grant was ingested before the Grants.gov data for the same grant. Currently, this manifests as a time-parsing error, since an empty string cannot be parsed according to the expected `MMDDYYYY` format, which prevents `processRecord()` from moving forward with uploading the record to S3.

Cases where `LastUpdatedDate` cannot be parsed should generally result in an error, since we want to be alerted if records regularly contain un-parseable values. However, given that FFIS data may be ingested for a grant before Grants.gov data (although it should be fairly uncommon), we need to be able to handle the possibility that `LastUpdatedDate` may not yet be present for a grant record stored in DynamoDB. To handle this scenario gracefully, we simply check for a blank `LastUpdatedDate` value before attempting to parse it. If the value is blank, we represent the `*time.Time` value as `nil`, which is consistent with the behavior implemented when a DynamoDB record is altogether missing for a grant.

Unit tests have been revised to comprehensively cover each of the following scenarios that can be encountered when evaluating `LastUpdatedDate` values from DynamoDB:
- DynamoDB item does not exist
- DynamoDB item provides a `LastUpdatedDate` that is in the past relative to the record on-hand
- DynamoDB item provides a `LastUpdatedDate` that is in the future relative to the record on-hand
- DynamoDB item provides a `LastUpdatedDate` that is equal to that of the record on-hand
- DynamoDB item provides a `LastUpdatedDate` that is malformed / un-parseable
- DynamoDB item exists but `LastUpdatedDate` is blank or missing

## Testing

Should be sufficient to run unit tests.

### Automated and Unit Tests
- [x] Added Unit tests

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [x] Added PR reviewers
