### PR TITLE
Revert "Pin staticcheck version to 2023.1.6"

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -149,7 +149,6 @@ jobs:
         uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6 # v1.3.1
         with:
           install-go: false
-          version: 2023.1.6
 
   go-build:
     name: Ensure Go Builds


### PR DESCRIPTION
Reverts usdigitalresponse/grants-ingest#893 as a prerequisite for running CI on #942 .