### PR TITLE
Fix blocked network requests for `dependency-review` GHA job

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -26,6 +26,8 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            api.securityscorecards.dev
+            api.deps.dev
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           show-progress: 'false'


### PR DESCRIPTION
## Description

This PR allow-lists two new endpoints, the absence of which are currently causing the `dependency-review` job to fail in our CI pipeline. See https://github.com/actions/dependency-review-action/issues/609 for more details.